### PR TITLE
IV-23 innerView 삭제 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build
 .externalNativeBuild
 .cxx
 local.properties
+mendable.jar
+index.html

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
@@ -8,4 +10,27 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.realm.database) apply false
     alias(libs.plugins.google.services) apply false
+}
+
+allprojects {
+    tasks.withType<KotlinCompile>().configureEach {
+        compilerOptions {
+
+            // Trigger this with:
+            // ./gradlew assembleRelease -PenableMultiModuleComposeReports=true --rerun-tasks
+            // java -jar mendable.jar --scanPaths .\build\compose_metrics\
+
+            if (project.findProperty("enableMultiModuleComposeReports") == "true") {
+                val buildDirPath = rootProject.layout.buildDirectory.get().asFile.absolutePath
+                freeCompilerArgs.addAll(
+                    listOf(
+                        "-P",
+                        "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$buildDirPath/compose_metrics/",
+                        "-P",
+                        "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$buildDirPath/compose_metrics/"
+                    )
+                )
+            }
+        }
+    }
 }

--- a/core/data-api/src/main/java/com/dev/innerview/core/data_api/InnerViewRepository.kt
+++ b/core/data-api/src/main/java/com/dev/innerview/core/data_api/InnerViewRepository.kt
@@ -9,4 +9,6 @@ interface InnerViewRepository {
     fun getInnerViews(): Flow<List<InnerView>>
 
     suspend fun addInnerView(title: String, type: InnerViewType)
+
+    suspend fun deleteInnerView(id: Int)
 }

--- a/core/data/src/main/java/com/dev/innerview/core/data/repository/InnerViewRepositoryImpl.kt
+++ b/core/data/src/main/java/com/dev/innerview/core/data/repository/InnerViewRepositoryImpl.kt
@@ -29,4 +29,8 @@ class InnerViewRepositoryImpl @Inject constructor(
     override suspend fun addInnerView(title: String, type: InnerViewType) {
         innerViewDataSource.addInnerView(title, type.name)
     }
+
+    override suspend fun deleteInnerView(id: Int) {
+        innerViewDataSource.deleteInnerView(id)
+    }
 }

--- a/core/database/src/main/java/com/dev/innerview/core/database/datasource/InnerViewDataSource.kt
+++ b/core/database/src/main/java/com/dev/innerview/core/database/datasource/InnerViewDataSource.kt
@@ -45,6 +45,13 @@ class InnerViewDataSource @Inject constructor(
         }
     }
 
+    suspend fun deleteInnerView(id: Int) {
+        realm.write {
+            val innerViewDelete = query<InnerViewSchema>("_id == $0", id).find().first()
+            delete(innerViewDelete)
+        }
+    }
+
     private fun getNextPrimaryKey(): Int {
         return realm.query<InnerViewSchema>().max("_id", Int::class).find { i ->
             if (i == null) {

--- a/core/designsystem/src/main/java/com/dev/innerview/core/designsystem/component/Dialog.kt
+++ b/core/designsystem/src/main/java/com/dev/innerview/core/designsystem/component/Dialog.kt
@@ -116,25 +116,25 @@ private fun InnerViewDialogPreview() {
             )
             InnerViewRadioButton(
                 textString = "1 year",
-                selected = { true },
+                selected = true,
                 onClick = {}
             )
             HorizontalDivider()
             InnerViewRadioButton(
                 textString = "1 month",
-                selected = { false },
+                selected = false,
                 onClick = {}
             )
             HorizontalDivider()
             InnerViewRadioButton(
                 textString = "1 week",
-                selected = { false },
+                selected = false,
                 onClick = {}
             )
             HorizontalDivider()
             InnerViewRadioButton(
                 textString = "매일",
-                selected = { false },
+                selected = false,
                 onClick = {}
             )
         }

--- a/core/designsystem/src/main/java/com/dev/innerview/core/designsystem/component/RadioButton.kt
+++ b/core/designsystem/src/main/java/com/dev/innerview/core/designsystem/component/RadioButton.kt
@@ -21,7 +21,7 @@ import com.dev.innerview.core.designsystem.theme.InnerViewTheme
 @Composable
 fun InnerViewRadioButton(
     textString: String = "",
-    selected: () -> Boolean,
+    selected: Boolean,
     onClick: () -> Unit
 ) {
     Row(
@@ -29,7 +29,7 @@ fun InnerViewRadioButton(
             .fillMaxWidth()
             .height(48.dp)
             .selectable(
-                selected = selected(),
+                selected = selected,
                 onClick = { onClick() },
                 role = Role.RadioButton
             ),
@@ -41,7 +41,7 @@ fun InnerViewRadioButton(
             style = MaterialTheme.typography.bodySmall,
         )
         RadioButton(
-            selected = selected(),
+            selected = selected,
             onClick = null,
             colors = RadioButtonColors(
                 selectedColor = MaterialTheme.colorScheme.tertiary,
@@ -60,7 +60,7 @@ private fun InnerViewRadioButtonPreview() {
     InnerViewTheme {
         InnerViewRadioButton(
             textString = "1 year",
-            selected = { true },
+            selected = true,
             onClick = {}
         )
     }

--- a/core/domain/src/main/java/com/dev/innerview/core/domain/usecase/DeleteInnerViewUseCase.kt
+++ b/core/domain/src/main/java/com/dev/innerview/core/domain/usecase/DeleteInnerViewUseCase.kt
@@ -1,0 +1,11 @@
+package com.dev.innerview.core.domain.usecase
+
+import com.dev.innerview.core.data_api.InnerViewRepository
+import javax.inject.Inject
+
+class DeleteInnerViewUseCase @Inject constructor(
+    private val innerViewRepository: InnerViewRepository
+) {
+    suspend operator fun invoke(id: Int) =
+        innerViewRepository.deleteInnerView(id)
+}

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/HomeScreen.kt
@@ -89,7 +89,10 @@ private fun HomeScreen(
         ) {
             InnerViewList(
                 homeUiState = homeUiState,
-                onInnerViewClick = onInnerViewClick
+                onInnerViewClick = onInnerViewClick,
+                onInnerViewLongClick = { viewModel.selectInnerView(it) },
+                onSelectInnerViewDelete = { viewModel.selectInnerViewDelete(it) },
+                onInnerViewDeleteRequest = { viewModel.deleteInnerView(it) }
             )
             InnerViewFloatingActionButton(
                 modifier = Modifier
@@ -118,6 +121,9 @@ private fun HomeScreen(
 private fun InnerViewList(
     homeUiState: HomeUiState,
     onInnerViewClick: (Int) -> Unit,
+    onInnerViewLongClick: (Int) -> Unit,
+    onSelectInnerViewDelete: (Int) -> Unit,
+    onInnerViewDeleteRequest: (Int) -> Unit
 ) {
     LazyColumn(
         modifier = Modifier
@@ -127,8 +133,11 @@ private fun InnerViewList(
     ) {
         items(homeUiState.innerViews, key = { it.id }) { innerView ->
             InnerViewItem(
-                innerView = innerView,
-                onInnerViewClick = onInnerViewClick
+                innerViewItemState = innerView,
+                onInnerViewClick = onInnerViewClick,
+                onInnerViewLongClick = onInnerViewLongClick,
+                onSelectInnerViewDelete = onSelectInnerViewDelete,
+                onInnerViewDeleteRequest = onInnerViewDeleteRequest
             )
         }
         item {

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/HomeScreen.kt
@@ -33,9 +33,12 @@ import com.dev.innerview.core.designsystem.component.TopAppBarNavigationType
 import com.dev.innerview.core.designsystem.component.appBarSize
 import com.dev.innerview.core.designsystem.theme.InnerViewTheme
 import com.dev.innerview.core.designsystem.theme.Paddings
+import com.dev.innerview.core.model.InnerViewType
 import com.dev.innerview.feature.home.component.InnerViewCreateDialog
 import com.dev.innerview.feature.home.component.InnerViewItem
 import com.dev.innerview.feature.home.model.HomeUiState
+import com.dev.innerview.feature.home.model.InnerViewItemUiState
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable
@@ -45,26 +48,42 @@ internal fun HomeRoute(
     navigateToInnerViewDetail: (Int) -> Unit,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
+    val homeUiState by viewModel.homeUiState.collectAsStateWithLifecycle()
+
     LaunchedEffect(true) {
         viewModel.errorFlow.collectLatest { throwable -> onShowErrorSnackBar(throwable) }
     }
 
     HomeScreen(
-        viewModel = viewModel,
+        homeUiState = homeUiState,
         padding = padding,
         navigateToInnerViewDetail = navigateToInnerViewDetail,
+        onInnerViewAddRequest = { viewModel.addInnerView() },
+        maxInnerViewTitleLength = viewModel.maxInnerViewTitleLength,
+        updateDialogInnerViewTitle = { viewModel.updateDialogInnerViewTitle(it) },
+        updateDialogSelectedType = { viewModel.updateDialogSelectedType(it) },
+        onInnerViewDeleteRequest = { viewModel.deleteInnerView(it) },
+        onSelectInnerViewDropdown = { viewModel.selectInnerViewDropdown(it) },
+        onSelectInnerViewCreate = { viewModel.selectInnerViewCreate() },
+        onSelectInnerViewDelete = { viewModel.selectInnerViewDelete(it) }
     )
 }
 
 
 @Composable
 private fun HomeScreen(
-    viewModel: HomeViewModel,
+    homeUiState: HomeUiState,
     padding: PaddingValues,
     navigateToInnerViewDetail: (Int) -> Unit,
+    onInnerViewAddRequest: () -> Unit,
+    onInnerViewDeleteRequest: (Int) -> Unit,
+    maxInnerViewTitleLength: Int,
+    updateDialogInnerViewTitle: (String) -> Unit,
+    updateDialogSelectedType: (InnerViewType) -> Unit,
+    onSelectInnerViewDropdown: (Int) -> Unit,
+    onSelectInnerViewCreate: () -> Unit,
+    onSelectInnerViewDelete: (Int) -> Unit
 ) {
-    val homeUiState by viewModel.homeUiState.collectAsStateWithLifecycle()
-
     Box(
         modifier = Modifier
             .padding(padding)
@@ -89,10 +108,10 @@ private fun HomeScreen(
         ) {
             InnerViewList(
                 homeUiState = homeUiState,
-                navigateToInnerViewDetail = navigateToInnerViewDetail,
-                onSelectInnerViewDropdown = { viewModel.selectInnerViewDropdown(it) },
-                onSelectInnerViewDelete = { viewModel.selectInnerViewDelete(it) },
-                onInnerViewDeleteRequest = { viewModel.deleteInnerView(it) }
+                onInnerViewClick = navigateToInnerViewDetail,
+                onSelectInnerViewDropdown = onSelectInnerViewDropdown,
+                onSelectInnerViewDelete = onSelectInnerViewDelete,
+                onInnerViewDeleteRequest = onInnerViewDeleteRequest
             )
             InnerViewFloatingActionButton(
                 modifier = Modifier
@@ -100,18 +119,18 @@ private fun HomeScreen(
                     .padding(end = Paddings.large, bottom = Paddings.large),
                 iconImageVector = Icons.Filled.Add,
                 text = stringResource(R.string.feature_home_innerview_create),
-                onClick = { viewModel.selectInnerViewCreate() }
+                onClick = onSelectInnerViewCreate
             )
         }
 
         if (homeUiState.isInnerViewCreateDialogVisible) {
             InnerViewCreateDialog(
                 homeUiState = homeUiState,
-                maxInnerViewTitleLength = viewModel.maxInnerViewTitleLength,
-                onTitleChange = { viewModel.updateDialogInnerViewTitle(it) },
-                onSelectType = { viewModel.updateDialogSelectedType(it) },
-                onDismissRequest = { viewModel.selectInnerViewCreate() },
-                onConfirmRequest = { viewModel.addInnerView() }
+                maxInnerViewTitleLength = maxInnerViewTitleLength,
+                onTitleChange = updateDialogInnerViewTitle,
+                onSelectType = updateDialogSelectedType,
+                onDismissRequest = onSelectInnerViewCreate,
+                onConfirmRequest = onInnerViewAddRequest
             )
         }
     }
@@ -120,7 +139,7 @@ private fun HomeScreen(
 @Composable
 private fun InnerViewList(
     homeUiState: HomeUiState,
-    navigateToInnerViewDetail: (Int) -> Unit,
+    onInnerViewClick: (Int) -> Unit,
     onSelectInnerViewDropdown: (Int) -> Unit,
     onSelectInnerViewDelete: (Int) -> Unit,
     onInnerViewDeleteRequest: (Int) -> Unit
@@ -134,7 +153,7 @@ private fun InnerViewList(
         items(homeUiState.innerViews, key = { it.id }) { innerView ->
             InnerViewItem(
                 innerViewItemState = innerView,
-                onInnerViewClick = navigateToInnerViewDetail,
+                onInnerViewClick = onInnerViewClick,
                 onInnerViewLongClick = onSelectInnerViewDropdown,
                 onSelectInnerViewDelete = onSelectInnerViewDelete,
                 onInnerViewDeleteRequest = onInnerViewDeleteRequest
@@ -152,9 +171,28 @@ private fun InnerViewList(
 private fun HomeScreenPreview() {
     InnerViewTheme {
         HomeScreen(
-            viewModel = hiltViewModel(),
+            homeUiState = HomeUiState(
+                innerViews = persistentListOf(
+                    InnerViewItemUiState(
+                        id = 1,
+                        title = "innerView title 1"
+                    ),
+                    InnerViewItemUiState(
+                        id = 2,
+                        title = "innerView title 2"
+                    )
+                )
+            ),
             padding = PaddingValues(),
             navigateToInnerViewDetail = {},
+            onInnerViewAddRequest = {},
+            maxInnerViewTitleLength = 0,
+            updateDialogInnerViewTitle = {},
+            updateDialogSelectedType = {},
+            onInnerViewDeleteRequest = {},
+            onSelectInnerViewDropdown = {},
+            onSelectInnerViewCreate = {},
+            onSelectInnerViewDelete = {}
         )
     }
 }

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/HomeScreen.kt
@@ -81,17 +81,6 @@ private fun HomeScreen(
             }
         )
 
-        if (homeUiState.isInnerViewCreateDialogVisible) {
-            InnerViewCreateDialog(
-                homeUiState = homeUiState,
-                maxInnerViewTitleLength = viewModel.maxInnerViewTitleLength,
-                onTitleChange = { viewModel.updateDialogInnerViewTitle(it) },
-                onSelectType = { viewModel.updateDialogSelectedType(it) },
-                onDismissRequest = { viewModel.closeInnerViewCreateDialog() },
-                onConfirmRequest = { viewModel.addInnerView() }
-            )
-        }
-
         Box(
             modifier = Modifier
                 .padding(top = appBarSize)
@@ -108,7 +97,18 @@ private fun HomeScreen(
                     .padding(end = Paddings.large, bottom = Paddings.large),
                 iconImageVector = Icons.Filled.Add,
                 text = stringResource(R.string.feature_home_innerview_create),
-                onClick = { viewModel.openInnerViewCreateDialog() }
+                onClick = { viewModel.selectInnerViewCreate() }
+            )
+        }
+
+        if (homeUiState.isInnerViewCreateDialogVisible) {
+            InnerViewCreateDialog(
+                homeUiState = homeUiState,
+                maxInnerViewTitleLength = viewModel.maxInnerViewTitleLength,
+                onTitleChange = { viewModel.updateDialogInnerViewTitle(it) },
+                onSelectType = { viewModel.updateDialogSelectedType(it) },
+                onDismissRequest = { viewModel.selectInnerViewCreate() },
+                onConfirmRequest = { viewModel.addInnerView() }
             )
         }
     }

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/HomeScreen.kt
@@ -38,6 +38,7 @@ import com.dev.innerview.feature.home.component.InnerViewCreateDialog
 import com.dev.innerview.feature.home.component.InnerViewItem
 import com.dev.innerview.feature.home.model.HomeUiState
 import com.dev.innerview.feature.home.model.InnerViewItemUiState
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.collectLatest
 
@@ -107,7 +108,7 @@ private fun HomeScreen(
                 .background(MaterialTheme.colorScheme.background)
         ) {
             InnerViewList(
-                homeUiState = homeUiState,
+                innerViews = homeUiState.innerViews,
                 onInnerViewClick = navigateToInnerViewDetail,
                 onSelectInnerViewDropdown = onSelectInnerViewDropdown,
                 onSelectInnerViewDelete = onSelectInnerViewDelete,
@@ -138,7 +139,7 @@ private fun HomeScreen(
 
 @Composable
 private fun InnerViewList(
-    homeUiState: HomeUiState,
+    innerViews: ImmutableList<InnerViewItemUiState>,
     onInnerViewClick: (Int) -> Unit,
     onSelectInnerViewDropdown: (Int) -> Unit,
     onSelectInnerViewDelete: (Int) -> Unit,
@@ -150,7 +151,7 @@ private fun InnerViewList(
             .padding(Paddings.large),
         verticalArrangement = Arrangement.spacedBy(Paddings.large)
     ) {
-        items(homeUiState.innerViews, key = { it.id }) { innerView ->
+        items(innerViews, key = { it.id }) { innerView ->
             InnerViewItem(
                 innerViewItemState = innerView,
                 onInnerViewClick = onInnerViewClick,

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/HomeScreen.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.flow.collectLatest
 internal fun HomeRoute(
     padding: PaddingValues,
     onShowErrorSnackBar: (throwable: Throwable?) -> Unit,
-    onInnerViewClick: (Int) -> Unit,
+    navigateToInnerViewDetail: (Int) -> Unit,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
     LaunchedEffect(true) {
@@ -52,7 +52,7 @@ internal fun HomeRoute(
     HomeScreen(
         viewModel = viewModel,
         padding = padding,
-        onInnerViewClick = onInnerViewClick,
+        navigateToInnerViewDetail = navigateToInnerViewDetail,
     )
 }
 
@@ -61,7 +61,7 @@ internal fun HomeRoute(
 private fun HomeScreen(
     viewModel: HomeViewModel,
     padding: PaddingValues,
-    onInnerViewClick: (Int) -> Unit,
+    navigateToInnerViewDetail: (Int) -> Unit,
 ) {
     val homeUiState by viewModel.homeUiState.collectAsStateWithLifecycle()
 
@@ -89,8 +89,8 @@ private fun HomeScreen(
         ) {
             InnerViewList(
                 homeUiState = homeUiState,
-                onInnerViewClick = onInnerViewClick,
-                onInnerViewLongClick = { viewModel.selectInnerView(it) },
+                navigateToInnerViewDetail = navigateToInnerViewDetail,
+                onSelectInnerViewDropdown = { viewModel.selectInnerViewDropdown(it) },
                 onSelectInnerViewDelete = { viewModel.selectInnerViewDelete(it) },
                 onInnerViewDeleteRequest = { viewModel.deleteInnerView(it) }
             )
@@ -120,8 +120,8 @@ private fun HomeScreen(
 @Composable
 private fun InnerViewList(
     homeUiState: HomeUiState,
-    onInnerViewClick: (Int) -> Unit,
-    onInnerViewLongClick: (Int) -> Unit,
+    navigateToInnerViewDetail: (Int) -> Unit,
+    onSelectInnerViewDropdown: (Int) -> Unit,
     onSelectInnerViewDelete: (Int) -> Unit,
     onInnerViewDeleteRequest: (Int) -> Unit
 ) {
@@ -134,8 +134,8 @@ private fun InnerViewList(
         items(homeUiState.innerViews, key = { it.id }) { innerView ->
             InnerViewItem(
                 innerViewItemState = innerView,
-                onInnerViewClick = onInnerViewClick,
-                onInnerViewLongClick = onInnerViewLongClick,
+                onInnerViewClick = navigateToInnerViewDetail,
+                onInnerViewLongClick = onSelectInnerViewDropdown,
                 onSelectInnerViewDelete = onSelectInnerViewDelete,
                 onInnerViewDeleteRequest = onInnerViewDeleteRequest
             )
@@ -154,7 +154,7 @@ private fun HomeScreenPreview() {
         HomeScreen(
             viewModel = hiltViewModel(),
             padding = PaddingValues(),
-            onInnerViewClick = {},
+            navigateToInnerViewDetail = {},
         )
     }
 }

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/HomeViewModel.kt
@@ -64,6 +64,10 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    fun deleteInnerView(id: Int) {
+        viewModelScope.launch {
+            println("innerView: $id 삭제")
+            selectInnerViewDelete(id)
         }
     }
 
@@ -73,6 +77,38 @@ class HomeViewModel @Inject constructor(
                 isInnerViewCreateDialogVisible = !it.isInnerViewCreateDialogVisible,
                 dialogInnerViewTitle = "",
                 dialogSelectedType = InnerViewType.YEAR
+            )
+        }
+    }
+
+    fun selectInnerViewDelete(id: Int) {
+        _homeUiState.update {
+            it.copy(
+                innerViews = it.innerViews.map { itemUiState ->
+                    if (itemUiState.id == id) {
+                        itemUiState.copy(
+                            isInnerViewDeleteDialogVisible = !itemUiState.isInnerViewDeleteDialogVisible
+                        )
+                    } else {
+                        itemUiState
+                    }
+                }.toPersistentList()
+            )
+        }
+    }
+
+    fun selectInnerView(id: Int) {
+        _homeUiState.update {
+            it.copy(
+                innerViews = it.innerViews.map { itemUiState ->
+                    if (itemUiState.id == id) {
+                        itemUiState.copy(
+                            isDropdownMenuVisible = !itemUiState.isDropdownMenuVisible
+                        )
+                    } else {
+                        itemUiState
+                    }
+                }.toPersistentList()
             )
         }
     }

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/HomeViewModel.kt
@@ -6,6 +6,7 @@ import com.dev.innerview.core.domain.usecase.AddInnerViewUseCase
 import com.dev.innerview.core.domain.usecase.GetInnerViewUseCase
 import com.dev.innerview.core.model.InnerViewType
 import com.dev.innerview.feature.home.model.HomeUiState
+import com.dev.innerview.feature.home.model.InnerViewItemUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -13,6 +14,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -34,9 +36,18 @@ class HomeViewModel @Inject constructor(
 
     init {
         getInnerViewUseCase()
-            .onEach { innerViews ->
+            .map { innerViews ->
+                innerViews.map { innerView ->
+                    InnerViewItemUiState(
+                        id = innerView.id,
+                        title = innerView.title,
+                        type = innerView.type,
+                        createdAt = innerView.createdAt
+                    )
+                }
+            }.onEach { innerViewItemStates ->
                 _homeUiState.update {
-                    it.copy(innerViews = innerViews.toPersistentList())
+                    it.copy(innerViews = innerViewItemStates.toPersistentList())
                 }
             }.launchIn(viewModelScope)
     }

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/HomeViewModel.kt
@@ -48,21 +48,18 @@ class HomeViewModel @Inject constructor(
                     _homeUiState.value.dialogInnerViewTitle,
                     _homeUiState.value.dialogSelectedType
                 )
-                closeInnerViewCreateDialog()
+                selectInnerViewCreate()
             }
         }
     }
 
-    fun openInnerViewCreateDialog() {
-        _homeUiState.update {
-            it.copy(isInnerViewCreateDialogVisible = true)
         }
     }
 
-    fun closeInnerViewCreateDialog() {
+    fun selectInnerViewCreate() {
         _homeUiState.update {
             it.copy(
-                isInnerViewCreateDialogVisible = false,
+                isInnerViewCreateDialogVisible = !it.isInnerViewCreateDialogVisible,
                 dialogInnerViewTitle = "",
                 dialogSelectedType = InnerViewType.YEAR
             )

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/HomeViewModel.kt
@@ -3,6 +3,7 @@ package com.dev.innerview.feature.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.dev.innerview.core.domain.usecase.AddInnerViewUseCase
+import com.dev.innerview.core.domain.usecase.DeleteInnerViewUseCase
 import com.dev.innerview.core.domain.usecase.GetInnerViewUseCase
 import com.dev.innerview.core.model.InnerViewType
 import com.dev.innerview.feature.home.model.HomeUiState
@@ -23,7 +24,8 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     getInnerViewUseCase: GetInnerViewUseCase,
-    private val addInnerViewUseCase: AddInnerViewUseCase
+    private val addInnerViewUseCase: AddInnerViewUseCase,
+    private val deleteInnerViewUseCase: DeleteInnerViewUseCase
 ) : ViewModel() {
 
     val maxInnerViewTitleLength = 40
@@ -66,8 +68,7 @@ class HomeViewModel @Inject constructor(
 
     fun deleteInnerView(id: Int) {
         viewModelScope.launch {
-            println("innerView: $id 삭제")
-            selectInnerViewDelete(id)
+            deleteInnerViewUseCase(id)
         }
     }
 

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/HomeViewModel.kt
@@ -98,7 +98,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun selectInnerView(id: Int) {
+    fun selectInnerViewDropdown(id: Int) {
         _homeUiState.update {
             it.copy(
                 innerViews = it.innerViews.map { itemUiState ->

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/component/InnerViewCreateDialog.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/component/InnerViewCreateDialog.kt
@@ -46,7 +46,7 @@ fun InnerViewCreateDialog(
             }
             InnerViewRadioButton(
                 textString = typeText,
-                selected = { homeUiState.dialogSelectedType == type },
+                selected = homeUiState.dialogSelectedType == type,
                 onClick = { onSelectType(type) }
             )
             if (InnerViewType.entries.size - 1 > i) {

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/component/InnerViewCreateDialog.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/component/InnerViewCreateDialog.kt
@@ -24,8 +24,8 @@ fun InnerViewCreateDialog(
 ) {
     InnerViewDialog(
         titleText = stringResource(id = R.string.feature_home_innerview_create),
-        contentText = stringResource(id = R.string.feature_home_innerview_type_description),
-        confirmText = stringResource(id = R.string.feature_home_dialog_confirm),
+        contentText = stringResource(id = R.string.feature_home_innerview_create_dialog_content),
+        confirmText = stringResource(id = R.string.feature_home_innerview_create_dialog_confirm),
         dismissText = stringResource(id = R.string.feature_home_dialog_dismiss),
         onDismissRequest = { onDismissRequest() },
         onConfirmRequest = { onConfirmRequest() }
@@ -33,8 +33,8 @@ fun InnerViewCreateDialog(
         InnerViewDialogTextField(
             value = { homeUiState.dialogInnerViewTitle },
             onValueChange = { onTitleChange(it) },
-            placeholderText = stringResource(id = R.string.feature_home_innerview_create_placeholder),
-            labelText = stringResource(id = R.string.feature_home_innerview_create_label),
+            placeholderText = stringResource(id = R.string.feature_home_innerview_create_dialog_placeholder),
+            labelText = stringResource(id = R.string.feature_home_innerview_create_dialog_label),
             supportingText = "${homeUiState.dialogInnerViewTitle.length}/$maxInnerViewTitleLength"
         )
         InnerViewType.entries.forEachIndexed { i, type ->

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/component/InnerViewDropdownMenu.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/component/InnerViewDropdownMenu.kt
@@ -1,0 +1,43 @@
+package com.dev.innerview.feature.home.component
+
+import androidx.compose.foundation.background
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.dev.innerview.feature.home.R
+import com.dev.innerview.feature.home.model.InnerViewItemUiState
+
+@Composable
+fun InnerViewDropdownMenu(
+    modifier: Modifier = Modifier,
+    itemUiState: InnerViewItemUiState,
+    onDeleteInnerView: (Int) -> Unit,
+    onDismissRequest: (Int) -> Unit
+) {
+    DropdownMenu(
+        modifier = modifier.background(MaterialTheme.colorScheme.background),
+        expanded = itemUiState.isDropdownMenuVisible,
+        onDismissRequest = {
+            onDismissRequest(itemUiState.id)
+        }
+    ) {
+        DropdownMenuItem(
+            text = {
+                Text(
+                    text = stringResource(R.string.feature_home_innerview_delete),
+                    style = MaterialTheme.typography.labelMedium.copy(
+                        color = MaterialTheme.colorScheme.error
+                    )
+                )
+            },
+            onClick = {
+                onDeleteInnerView(itemUiState.id)
+                onDismissRequest(itemUiState.id)
+            }
+        )
+    }
+}

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/component/InnerViewItem.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/component/InnerViewItem.kt
@@ -1,7 +1,8 @@
 package com.dev.innerview.feature.home.component
 
 import android.content.res.Configuration
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,34 +17,42 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.dev.innerview.core.designsystem.component.InnerViewCard
+import com.dev.innerview.core.designsystem.component.InnerViewDialog
 import com.dev.innerview.core.designsystem.theme.InnerViewTheme
 import com.dev.innerview.core.designsystem.theme.Paddings
-import com.dev.innerview.core.model.InnerView
 import com.dev.innerview.core.model.InnerViewType
 import com.dev.innerview.feature.home.R
+import com.dev.innerview.feature.home.model.InnerViewItemUiState
 import java.time.Duration
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun InnerViewItem(
-    innerView: InnerView,
-    onInnerViewClick: (Int) -> Unit
+    innerViewItemState: InnerViewItemUiState,
+    onInnerViewClick: (Int) -> Unit,
+    onInnerViewLongClick: (Int) -> Unit,
+    onSelectInnerViewDelete: (Int) -> Unit,
+    onInnerViewDeleteRequest: (Int) -> Unit
 ) {
 
-    val createdAt = innerView.createdAt.withZoneSameInstant(ZoneId.systemDefault())
+    val createdAt = innerViewItemState.createdAt.withZoneSameInstant(ZoneId.systemDefault())
         .format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
 
     val daysBetween =
-        Duration.between(innerView.createdAt, ZonedDateTime.now(ZoneOffset.UTC)).toDays()
+        Duration.between(innerViewItemState.createdAt, ZonedDateTime.now(ZoneOffset.UTC)).toDays()
 
     InnerViewCard(
         modifier = Modifier
             .fillMaxWidth()
             .height(80.dp)
-            .clickable { onInnerViewClick(innerView.id) }
+            .combinedClickable(
+                onClick = { onInnerViewClick(innerViewItemState.id) },
+                onLongClick = { onInnerViewLongClick(innerViewItemState.id) }
+            )
     ) {
         Box(
             modifier = Modifier
@@ -52,7 +61,7 @@ fun InnerViewItem(
         ) {
             Text(
                 modifier = Modifier.align(Alignment.TopStart),
-                text = innerView.title,
+                text = innerViewItemState.title,
                 style = MaterialTheme.typography.titleSmall,
                 maxLines = 2
             )
@@ -60,12 +69,11 @@ fun InnerViewItem(
             Text(
                 modifier = Modifier.align(Alignment.BottomStart),
                 text = "$createdAt ~ D+${daysBetween}",
-//                text = innerView.createdAt.toString(),
                 style = MaterialTheme.typography.labelMedium
             )
             Text(
                 modifier = Modifier.align(Alignment.BottomEnd),
-                text = when (innerView.type) {
+                text = when (innerViewItemState.type) {
                     InnerViewType.YEAR -> stringResource(id = R.string.feature_home_innerview_type_year)
                     InnerViewType.MONTH -> stringResource(id = R.string.feature_home_innerview_type_month)
                     InnerViewType.WEEK -> stringResource(id = R.string.feature_home_innerview_type_week)
@@ -73,7 +81,30 @@ fun InnerViewItem(
                 },
                 style = MaterialTheme.typography.labelSmall
             )
+            InnerViewDropdownMenu(
+                modifier = Modifier,
+                itemUiState = innerViewItemState,
+                onDeleteInnerView = { onSelectInnerViewDelete(innerViewItemState.id) },
+                onDismissRequest = { onInnerViewLongClick(innerViewItemState.id) }
+            )
         }
+    }
+
+    if (innerViewItemState.isInnerViewDeleteDialogVisible) {
+        InnerViewDialog(
+            titleText = stringResource(
+                R.string.feature_home_innerview_delete_dialog_title,
+                innerViewItemState.title
+            ),
+            contentText = stringResource(
+                R.string.feature_home_innerview_delete_dialog_content,
+                innerViewItemState.title
+            ),
+            confirmText = stringResource(R.string.feature_home_innerview_delete),
+            dismissText = stringResource(R.string.feature_home_dialog_dismiss),
+            onDismissRequest = { onSelectInnerViewDelete(innerViewItemState.id) },
+            onConfirmRequest = { onInnerViewDeleteRequest(innerViewItemState.id) }
+        )
     }
 }
 
@@ -84,11 +115,15 @@ private fun InnerViewContentPreview() {
     InnerViewTheme {
         InnerViewItem(
             onInnerViewClick = {},
-            innerView = InnerView(
+            onInnerViewLongClick = {},
+            onSelectInnerViewDelete = {},
+            onInnerViewDeleteRequest = {},
+            innerViewItemState = InnerViewItemUiState(
                 id = 0,
                 title = "innerView title",
                 type = InnerViewType.YEAR,
-                createdAt = ZonedDateTime.now(ZoneOffset.UTC)
+                createdAt = ZonedDateTime.now(ZoneOffset.UTC),
+                isInnerViewDeleteDialogVisible = true,
             )
         )
     }

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/model/HomeUiState.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/model/HomeUiState.kt
@@ -8,7 +8,7 @@ import kotlinx.collections.immutable.persistentListOf
 
 @Immutable
 data class HomeUiState(
-    val innerViews: ImmutableList<InnerView> = persistentListOf(),
+    val innerViews: ImmutableList<InnerViewItemUiState> = persistentListOf(),
     val isInnerViewCreateDialogVisible: Boolean = false,
     val dialogInnerViewTitle: String = "",
     val dialogSelectedType: InnerViewType = InnerViewType.YEAR

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/model/InnerViewItemUiState.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/model/InnerViewItemUiState.kt
@@ -1,0 +1,13 @@
+package com.dev.innerview.feature.home.model
+
+import com.dev.innerview.core.model.InnerViewType
+import java.time.ZonedDateTime
+
+data class InnerViewItemUiState(
+    val id: Int = 0,
+    val title: String = "",
+    val type: InnerViewType = InnerViewType.YEAR,
+    val createdAt: ZonedDateTime = ZonedDateTime.now(),
+    val isDropdownMenuVisible: Boolean = false,
+    val isInnerViewDeleteDialogVisible: Boolean = false
+)

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/model/InnerViewItemUiState.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/model/InnerViewItemUiState.kt
@@ -1,8 +1,10 @@
 package com.dev.innerview.feature.home.model
 
+import androidx.compose.runtime.Immutable
 import com.dev.innerview.core.model.InnerViewType
 import java.time.ZonedDateTime
 
+@Immutable
 data class InnerViewItemUiState(
     val id: Int = 0,
     val title: String = "",

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/navigation/HomeNavigation.kt
@@ -41,7 +41,7 @@ fun NavGraphBuilder.homeNavGraph(
         HomeRoute(
             padding = padding,
             onShowErrorSnackBar = onShowErrorSnackBar,
-            onInnerViewClick = onInnerViewClick
+            navigateToInnerViewDetail = onInnerViewClick
         )
     }
 

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -2,17 +2,20 @@
     <string name="feature_home_innerview_screen_title">innerView</string>
     <string name="feature_home_icon_description_upload">업로드</string>
     <string name="feature_home_innerview_create">이너뷰 생성</string>
-    <string name="feature_home_innerview_title">이너뷰 제목</string>
-    <string name="feature_home_innerview_type_description">1 year : 1년에 한 번 같은 질문으로 인터뷰\n1 month : 1달에 한 번 같은 질문으로 인터뷰\n1 week: 1주일에 한 번 같은 질문으로 인터뷰\n매일 : 매일 다른 질문으로 인터뷰</string>
-
-    <string name="feature_home_dialog_confirm">생성</string>
-    <string name="feature_home_dialog_dismiss">취소</string>
 
     <string name="feature_home_innerview_type_year">1 year</string>
     <string name="feature_home_innerview_type_month">1 month</string>
     <string name="feature_home_innerview_type_week">1 week</string>
     <string name="feature_home_innerview_type_day">매일</string>
 
-    <string name="feature_home_innerview_create_placeholder">이너뷰 제목을 입력하세요.</string>
-    <string name="feature_home_innerview_create_label">이너뷰 제목</string>
+    <string name="feature_home_dialog_dismiss">취소</string>
+
+    <string name="feature_home_innerview_create_dialog_placeholder">이너뷰 제목을 입력하세요.</string>
+    <string name="feature_home_innerview_create_dialog_label">이너뷰 제목</string>
+    <string name="feature_home_innerview_create_dialog_confirm">생성</string>
+    <string name="feature_home_innerview_create_dialog_content">1 year : 1년에 한 번 같은 질문으로 인터뷰\n1 month : 1달에 한 번 같은 질문으로 인터뷰\n1 week: 1주일에 한 번 같은 질문으로 인터뷰\n매일 : 매일 다른 질문으로 인터뷰</string>
+
+    <string name="feature_home_innerview_delete_dialog_title">%1$s 삭제</string>
+    <string name="feature_home_innerview_delete_dialog_content">%1$s을(를) 삭제하시겠습니까?\n삭제 시, 해당 항목에 포함된 모든 인터뷰도 함께 삭제됩니다.\n삭제 진행 전, 필요한 인터뷰는 서버에 백업하거나 갤러리에 저장해 주시기 바랍니다.\n삭제를 계속하시겠습니까?</string>
+    <string name="feature_home_innerview_delete">삭제</string>
 </resources>


### PR DESCRIPTION
## 개요
- InnerViewItemUiState 추가
- realmDB InnerView 삭제 로직 추가
- InnerView 롱클릭, 드롭다운, 다이얼로그 순서로 삭제 기능 연결

## 스크릿샷
![GIF](https://github.com/user-attachments/assets/e294e88e-526c-444c-bb09-846d374ebec1)

---
- ~~여전히 요소가 변경되면 lazy Column 내부 모든 item이 recomposition 되는 문제가 있습니다.~~
- LazyColumn 요소 변경될 때, 전체 Item이 recomposition 되는 문제 해결 했습니다.
  - 내부 요소에 Immutable 어노테이션을 추가하지 않아서 무조건적으로 recomposition 되었던 것 같습니다.
- 추가로 mendable 셋팅 추가하여 composable 함수 분석하기 편하도록 설정했습니다.