### PR TITLE
IV-47 영상 순서 변경 기능

### DIFF
--- a/feature/edit/src/main/java/com/dev/innerview/feature/edit/EditScreen.kt
+++ b/feature/edit/src/main/java/com/dev/innerview/feature/edit/EditScreen.kt
@@ -60,6 +60,7 @@ import com.dev.innerview.feature.edit.component.PlayerView
 import com.dev.innerview.feature.edit.model.EditUiState
 import com.dev.innerview.feature.edit.model.MediaItemSide
 import com.dev.innerview.feature.edit.model.MediaUiState
+import com.dev.innerview.feature.edit.model.PositionUpdateOption
 import com.dev.innerview.feature.edit.model.SplitOption
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.collectLatest
@@ -95,6 +96,7 @@ internal fun EditScreen(
         splitMediaItem = viewModel::splitMediaItem,
         deleteMediaItem = viewModel::deleteMediaItem,
         updateMediaItemLengthen = viewModel::updateMediaItemLengthen,
+        updateMediaItemPosition = viewModel::updateMediaItemPosition,
     )
 }
 
@@ -115,6 +117,7 @@ private fun EditContent(
     splitMediaItem: (SplitOption) -> Unit,
     deleteMediaItem: () -> Unit,
     updateMediaItemLengthen: (MediaItemSide, Int, Int) -> Unit,
+    updateMediaItemPosition: (PositionUpdateOption) -> Unit,
 ) {
     val density = LocalDensity.current
     val scrollState = rememberScrollState()
@@ -307,6 +310,7 @@ private fun EditContent(
                     cancelMediaItem = cancelMediaItem,
                     splitMediaItem = splitMediaItem,
                     deleteMediaItem = deleteMediaItem,
+                    updateMediaItemPosition = updateMediaItemPosition,
                 )
             }
         }
@@ -360,6 +364,7 @@ private fun EditContentPreview() {
             splitMediaItem = {},
             deleteMediaItem = {},
             updateMediaItemLengthen = { _, _, _ -> },
+            updateMediaItemPosition = {},
         )
     }
 }

--- a/feature/edit/src/main/java/com/dev/innerview/feature/edit/EditViewModel.kt
+++ b/feature/edit/src/main/java/com/dev/innerview/feature/edit/EditViewModel.kt
@@ -15,6 +15,7 @@ import com.dev.innerview.core.playback.playstate.PlaybackStateManager
 import com.dev.innerview.feature.edit.model.EditUiState
 import com.dev.innerview.feature.edit.model.MediaItemSide
 import com.dev.innerview.feature.edit.model.MediaUiState
+import com.dev.innerview.feature.edit.model.PositionUpdateOption
 import com.dev.innerview.feature.edit.model.SplitOption
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -377,6 +378,72 @@ class EditViewModel @Inject constructor(
             )
         }
         fetchPlayer()
+    }
+
+    fun updateMediaItemPosition(positionUpdateOption: PositionUpdateOption) {
+        player.pause()
+        with(_editUiState.value) {
+            val selectedIndex = media.indexOfFirst { it.selected }
+            if (selectedIndex == -1) return
+
+            var newMedia = media.toPersistentList()
+            when (positionUpdateOption) {
+                PositionUpdateOption.START -> {
+                    val temp = newMedia[selectedIndex]
+                    newMedia = newMedia.removeAt(selectedIndex).add(0, temp)
+                }
+
+                PositionUpdateOption.LEFT -> {
+                    if (selectedIndex != 0) {
+                        val temp = newMedia[selectedIndex]
+                        newMedia = newMedia.set(selectedIndex, newMedia[selectedIndex - 1])
+                            .set(selectedIndex - 1, temp)
+                    } else {
+                        return
+                    }
+                }
+
+                PositionUpdateOption.RIGHT -> {
+                    if (selectedIndex != media.size - 1) {
+                        val temp = newMedia[selectedIndex]
+                        newMedia = newMedia.set(selectedIndex, newMedia[selectedIndex + 1])
+                            .set(selectedIndex + 1, temp)
+                    } else {
+                        return
+                    }
+                }
+
+                PositionUpdateOption.END -> {
+                    val temp = newMedia[selectedIndex]
+                    newMedia = newMedia.removeAt(selectedIndex).add(temp)
+                }
+            }
+
+            _editUiState.update {
+                it.copy(
+                    media = newMedia,
+                )
+            }
+
+            fetchPlayer()
+            when (positionUpdateOption) {
+                PositionUpdateOption.START -> {
+                    player.seekTo(0, 0)
+                }
+
+                PositionUpdateOption.LEFT -> {
+                    player.seekTo(selectedIndex - 1, 0)
+                }
+
+                PositionUpdateOption.RIGHT -> {
+                    player.seekTo(selectedIndex + 1, 0)
+                }
+
+                PositionUpdateOption.END -> {
+                    player.seekTo(media.size - 1, 0)
+                }
+            }
+        }
     }
 
     private fun fetchPlayer() {

--- a/feature/edit/src/main/java/com/dev/innerview/feature/edit/component/MediaItemBottomBar.kt
+++ b/feature/edit/src/main/java/com/dev/innerview/feature/edit/component/MediaItemBottomBar.kt
@@ -13,14 +13,21 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.ContentCut
 import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.material.icons.filled.KeyboardDoubleArrowLeft
+import androidx.compose.material.icons.filled.KeyboardDoubleArrowRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -31,7 +38,9 @@ import androidx.compose.ui.unit.dp
 import com.dev.innerview.core.designsystem.theme.InnerViewTheme
 import com.dev.innerview.core.designsystem.theme.Paddings
 import com.dev.innerview.feature.edit.R
+import com.dev.innerview.feature.edit.model.PositionUpdateOption
 import com.dev.innerview.feature.edit.model.SplitOption
+import kotlinx.coroutines.launch
 
 @Composable
 fun MediaItemBottomBar(
@@ -40,7 +49,11 @@ fun MediaItemBottomBar(
     cancelMediaItem: () -> Unit,
     splitMediaItem: (SplitOption) -> Unit,
     deleteMediaItem: () -> Unit,
+    updateMediaItemPosition: (PositionUpdateOption) -> Unit,
 ) {
+    val coroutineScope = rememberCoroutineScope()
+    val pagerState = rememberPagerState(pageCount = { 2 })
+
     AnimatedVisibility(
         visible = isVisible,
         modifier = modifier,
@@ -52,97 +65,225 @@ fun MediaItemBottomBar(
             modifier = Modifier.fillMaxWidth()
         ) {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(MaterialTheme.colorScheme.onSurface)
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                IconButton(
-                    modifier = Modifier.weight(1f),
-                    onClick = { deleteMediaItem() }
-                ) {
-                    Column(
-                        verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.DeleteOutline,
-                            contentDescription = "ContentCut",
-                            tint = MaterialTheme.colorScheme.surfaceContainer
-                        )
-                        Text(
-                            modifier = Modifier.padding(top = Paddings.xsmall),
-                            text = "삭제",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.surfaceContainer
-                        )
+                Icon(
+                    modifier = Modifier.clickable {
+                        coroutineScope.launch {
+                            pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                        }
+                    },
+                    imageVector = Icons.Filled.ChevronLeft,
+                    contentDescription = "OptionPrev",
+                    tint = MaterialTheme.colorScheme.surfaceContainer
+                )
+                HorizontalPager(
+                    modifier = Modifier
+                        .weight(1f)
+                        .background(MaterialTheme.colorScheme.onSurface),
+                    state = pagerState
+                ) { page ->
+                    when (page) {
+                        0 -> {
+                            Row(
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                IconButton(
+                                    modifier = Modifier.weight(1f),
+                                    onClick = { deleteMediaItem() }
+                                ) {
+                                    Column(
+                                        verticalArrangement = Arrangement.Center,
+                                        horizontalAlignment = Alignment.CenterHorizontally
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Filled.DeleteOutline,
+                                            contentDescription = "ContentCut",
+                                            tint = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                        Text(
+                                            modifier = Modifier.padding(top = Paddings.xsmall),
+                                            text = "삭제",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                    }
+                                }
+                                IconButton(
+                                    modifier = Modifier.weight(1f),
+                                    onClick = { splitMediaItem(SplitOption.LEFT) }
+                                ) {
+                                    Column(
+                                        verticalArrangement = Arrangement.Center,
+                                        horizontalAlignment = Alignment.CenterHorizontally
+                                    ) {
+                                        Icon(
+                                            modifier = Modifier.size(24.dp),
+                                            imageVector = ImageVector.vectorResource(R.drawable.left_cut),
+                                            contentDescription = "ContentCut",
+                                            tint = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                        Text(
+                                            modifier = Modifier.padding(top = Paddings.xsmall),
+                                            text = "현재부터 자르기",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                    }
+                                }
+                                IconButton(
+                                    modifier = Modifier.weight(1f),
+                                    onClick = { splitMediaItem(SplitOption.NONE) }
+                                ) {
+                                    Column(
+                                        verticalArrangement = Arrangement.Center,
+                                        horizontalAlignment = Alignment.CenterHorizontally
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Filled.ContentCut,
+                                            contentDescription = "ContentCut",
+                                            tint = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                        Text(
+                                            modifier = Modifier.padding(top = Paddings.xsmall),
+                                            text = "분할",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                    }
+                                }
+                                IconButton(
+                                    modifier = Modifier.weight(1f),
+                                    onClick = { splitMediaItem(SplitOption.RIGHT) }
+                                ) {
+                                    Column(
+                                        verticalArrangement = Arrangement.Center,
+                                        horizontalAlignment = Alignment.CenterHorizontally
+                                    ) {
+                                        Icon(
+                                            modifier = Modifier.size(24.dp),
+                                            imageVector = ImageVector.vectorResource(R.drawable.right_cut),
+                                            contentDescription = "ContentCut",
+                                            tint = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                        Text(
+                                            modifier = Modifier.padding(top = Paddings.xsmall),
+                                            text = "현재까지 자르기",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                    }
+                                }
+                            }
+                        }
+
+                        1 -> {
+                            Row(
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                IconButton(
+                                    modifier = Modifier.weight(1f),
+                                    onClick = { updateMediaItemPosition(PositionUpdateOption.START) }
+                                ) {
+                                    Column(
+                                        verticalArrangement = Arrangement.Center,
+                                        horizontalAlignment = Alignment.CenterHorizontally
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Filled.KeyboardDoubleArrowLeft,
+                                            contentDescription = "ContentPositionChangeToStart",
+                                            tint = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                        Text(
+                                            modifier = Modifier.padding(top = Paddings.xsmall),
+                                            text = "맨 앞으로",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                    }
+                                }
+                                IconButton(
+                                    modifier = Modifier.weight(1f),
+                                    onClick = { updateMediaItemPosition(PositionUpdateOption.LEFT) }
+                                ) {
+                                    Column(
+                                        verticalArrangement = Arrangement.Center,
+                                        horizontalAlignment = Alignment.CenterHorizontally
+                                    ) {
+                                        Icon(
+                                            modifier = Modifier.size(24.dp),
+                                            imageVector = Icons.Filled.ChevronLeft,
+                                            contentDescription = "ContentPositionChangeToLeft",
+                                            tint = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                        Text(
+                                            modifier = Modifier.padding(top = Paddings.xsmall),
+                                            text = "왼쪽으로",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                    }
+                                }
+                                IconButton(
+                                    modifier = Modifier.weight(1f),
+                                    onClick = { updateMediaItemPosition(PositionUpdateOption.RIGHT) }
+                                ) {
+                                    Column(
+                                        verticalArrangement = Arrangement.Center,
+                                        horizontalAlignment = Alignment.CenterHorizontally
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Filled.ChevronRight,
+                                            contentDescription = "ContentPositionChangeToRight",
+                                            tint = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                        Text(
+                                            modifier = Modifier.padding(top = Paddings.xsmall),
+                                            text = "오른쪽으로",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                    }
+                                }
+                                IconButton(
+                                    modifier = Modifier.weight(1f),
+                                    onClick = { updateMediaItemPosition(PositionUpdateOption.END) }
+                                ) {
+                                    Column(
+                                        verticalArrangement = Arrangement.Center,
+                                        horizontalAlignment = Alignment.CenterHorizontally
+                                    ) {
+                                        Icon(
+                                            modifier = Modifier.size(24.dp),
+                                            imageVector = Icons.Filled.KeyboardDoubleArrowRight,
+                                            contentDescription = "ContentPositionChangeToEnd",
+                                            tint = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                        Text(
+                                            modifier = Modifier.padding(top = Paddings.xsmall),
+                                            text = "맨 뒤로",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.surfaceContainer
+                                        )
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
-                IconButton(
-                    modifier = Modifier.weight(1f),
-                    onClick = { splitMediaItem(SplitOption.LEFT) }
-                ) {
-                    Column(
-                        verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Icon(
-                            modifier = Modifier.size(24.dp),
-                            imageVector = ImageVector.vectorResource(R.drawable.left_cut),
-                            contentDescription = "ContentCut",
-                            tint = MaterialTheme.colorScheme.surfaceContainer
-                        )
-                        Text(
-                            modifier = Modifier.padding(top = Paddings.xsmall),
-                            text = "현재부터 자르기",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.surfaceContainer
-                        )
-                    }
-                }
-                IconButton(
-                    modifier = Modifier.weight(1f),
-                    onClick = { splitMediaItem(SplitOption.NONE) }
-                ) {
-                    Column(
-                        verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.ContentCut,
-                            contentDescription = "ContentCut",
-                            tint = MaterialTheme.colorScheme.surfaceContainer
-                        )
-                        Text(
-                            modifier = Modifier.padding(top = Paddings.xsmall),
-                            text = "분할",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.surfaceContainer
-                        )
-                    }
-                }
-                IconButton(
-                    modifier = Modifier.weight(1f),
-                    onClick = { splitMediaItem(SplitOption.RIGHT) }
-                ) {
-                    Column(
-                        verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Icon(
-                            modifier = Modifier.size(24.dp),
-                            imageVector = ImageVector.vectorResource(R.drawable.right_cut),
-                            contentDescription = "ContentCut",
-                            tint = MaterialTheme.colorScheme.surfaceContainer
-                        )
-                        Text(
-                            modifier = Modifier.padding(top = Paddings.xsmall),
-                            text = "현재까지 자르기",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.surfaceContainer
-                        )
-                    }
-                }
+                Icon(
+                    modifier = Modifier.clickable {
+                        coroutineScope.launch {
+                            pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                        }
+                    },
+                    imageVector = Icons.Filled.ChevronRight,
+                    contentDescription = "OptionNext",
+                    tint = MaterialTheme.colorScheme.surfaceContainer
+                )
             }
+
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -172,6 +313,7 @@ private fun MediaItemBottomBarPreview() {
             cancelMediaItem = {},
             splitMediaItem = {},
             deleteMediaItem = {},
+            updateMediaItemPosition = {},
         )
     }
 }

--- a/feature/edit/src/main/java/com/dev/innerview/feature/edit/component/PlayerBar.kt
+++ b/feature/edit/src/main/java/com/dev/innerview/feature/edit/component/PlayerBar.kt
@@ -48,20 +48,6 @@ fun PlayerBar(
     Column(
         modifier = Modifier.fillMaxWidth()
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(18.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center
-        ) {
-            Text(
-                text = "0",
-                fontSize = 12.sp,
-                color = Color.White,
-                textAlign = TextAlign.Center,
-            )
-        }
         HorizontalDivider(thickness = 1.dp, color = MaterialTheme.colorScheme.onSurface)
         Row(
             modifier = Modifier

--- a/feature/edit/src/main/java/com/dev/innerview/feature/edit/model/PositionUpdateOption.kt
+++ b/feature/edit/src/main/java/com/dev/innerview/feature/edit/model/PositionUpdateOption.kt
@@ -1,0 +1,8 @@
+package com.dev.innerview.feature.edit.model
+
+enum class PositionUpdateOption {
+    START,
+    LEFT,
+    RIGHT,
+    END
+}


### PR DESCRIPTION
## 개요
- PlayerBar 상단 레이어 삭제
- 영상 아이템 순서 변경 기능 추가
- HorizontalPager를 사용한 MediaItemBar 버튼 분리 및 기능 연결

## 스크린샷
![GIF](https://github.com/user-attachments/assets/5dd37694-2664-4a59-a1e2-e2040a70b70c)
