### PR TITLE
IV-143 인터뷰 촬영 편집 연결

### DIFF
--- a/feature/edit/src/main/java/com/dev/innerview/feature/edit/EditScreen.kt
+++ b/feature/edit/src/main/java/com/dev/innerview/feature/edit/EditScreen.kt
@@ -70,7 +70,6 @@ import kotlinx.coroutines.flow.filter
 
 @Composable
 internal fun EditScreen(
-    innerProjectId: Int,
     onShowErrorSnackBar: (throwable: Throwable?) -> Unit,
     onBackClick: () -> Unit,
     viewModel: EditViewModel = hiltViewModel(),
@@ -80,12 +79,10 @@ internal fun EditScreen(
     val mediaAddUiState by viewModel.mediaAddUiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
-        viewModel.fetchInnerProject(innerProjectId)
         viewModel.errorFlow.collectLatest { throwable -> onShowErrorSnackBar(throwable) }
     }
 
     EditContent(
-        innerProjectId = innerProjectId,
         player = viewModel.player,
         editUiState = editUiState,
         mediaAddUiState = mediaAddUiState,
@@ -111,7 +108,6 @@ internal fun EditScreen(
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 private fun EditContent(
-    innerProjectId: Int,
     player: Player?,
     editUiState: EditUiState,
     mediaAddUiState: MediaAddUiState,
@@ -338,7 +334,6 @@ private fun EditContent(
 private fun EditContentPreview() {
     InnerViewTheme {
         EditContent(
-            innerProjectId = 0,
             editUiState = EditUiState(
                 isPlaying = true,
                 duration = 6000L,

--- a/feature/edit/src/main/java/com/dev/innerview/feature/edit/EditScreen.kt
+++ b/feature/edit/src/main/java/com/dev/innerview/feature/edit/EditScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddCircleOutline
 import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.TextFields
@@ -83,6 +84,7 @@ internal fun EditScreen(
     }
 
     EditContent(
+        onShowErrorSnackBar = onShowErrorSnackBar,
         player = viewModel.player,
         editUiState = editUiState,
         mediaAddUiState = mediaAddUiState,
@@ -108,6 +110,7 @@ internal fun EditScreen(
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 private fun EditContent(
+    onShowErrorSnackBar: (throwable: Throwable?) -> Unit,
     player: Player?,
     editUiState: EditUiState,
     mediaAddUiState: MediaAddUiState,
@@ -156,12 +159,25 @@ private fun EditContent(
             navigationType = TopAppBarNavigationType.Back,
             onNavigationClick = { onBackClick() },
             actionButtons = {
-                InnerViewAppBarIcon(
-                    imageVector = Icons.Filled.Done,
-                    navigationIconContentDescription = null
-                )
+                when (editUiState.isRecording) {
+                    true -> {
+                        InnerViewAppBarIcon(
+                            imageVector = Icons.Filled.Done,
+                            navigationIconContentDescription = null,
+                            onClick = { onBackClick() }
+                        )
+                    }
+
+                    else -> {
+                        InnerViewAppBarIcon(
+                            imageVector = Icons.Filled.Download,
+                            navigationIconContentDescription = null
+                        )
+                    }
+                }
             }
         )
+
         Column(
             modifier = Modifier
                 .systemBarsPadding()
@@ -228,7 +244,10 @@ private fun EditContent(
                         seekToMediaItem = seekByMediaItem,
                         seekByPosition = seekByPosition,
                     )
-                    HorizontalDivider(thickness = 1.dp, color = MaterialTheme.colorScheme.onSurface)
+                    HorizontalDivider(
+                        thickness = 1.dp,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
 
                     Box(
                         modifier = Modifier
@@ -257,7 +276,17 @@ private fun EditContent(
                                     layerIcon = Icons.Filled.AddCircleOutline,
                                     layerIconDescription = "미디어 추가",
                                     layerName = "Media",
-                                    onLayerIconClick = { selectMediaAddBottomSheet() }
+                                    onLayerIconClick = {
+                                        when (editUiState.isRecording) {
+                                            true -> {
+                                                onShowErrorSnackBar(Throwable(message = "녹화 중인 인터뷰는 Media를 추가할 수 없습니다."))
+                                            }
+
+                                            else -> {
+                                                selectMediaAddBottomSheet()
+                                            }
+                                        }
+                                    }
                                 ) {
                                     for (i in 0 until editUiState.media.size) {
                                         val duration =
@@ -334,8 +363,10 @@ private fun EditContent(
 private fun EditContentPreview() {
     InnerViewTheme {
         EditContent(
+            onShowErrorSnackBar = { },
             editUiState = EditUiState(
                 isPlaying = true,
+                isRecording = true,
                 duration = 6000L,
                 zoom = 1f,
                 media = persistentListOf(

--- a/feature/edit/src/main/java/com/dev/innerview/feature/edit/EditViewModel.kt
+++ b/feature/edit/src/main/java/com/dev/innerview/feature/edit/EditViewModel.kt
@@ -2,10 +2,12 @@ package com.dev.innerview.feature.edit
 
 import android.content.Context
 import androidx.core.net.toUri
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.navigation.toRoute
 import com.dev.innerview.core.domain.usecase.GetInnerProjectByIdUseCase
 import com.dev.innerview.core.domain.usecase.GetInnerViewContentUseCase
 import com.dev.innerview.core.domain.usecase.GetInnerViewUseCase
@@ -13,6 +15,7 @@ import com.dev.innerview.core.domain.usecase.GetInterviewGroupContentUseCase
 import com.dev.innerview.core.domain.usecase.UpdateInnerProjectUseCase
 import com.dev.innerview.core.model.InnerProjectComponents
 import com.dev.innerview.core.model.InterviewPiece
+import com.dev.innerview.core.navigation.Route
 import com.dev.innerview.core.playback.playstate.PlaybackStateListener
 import com.dev.innerview.core.playback.playstate.PlaybackStateManager
 import com.dev.innerview.feature.edit.model.EditUiState
@@ -41,12 +44,12 @@ import javax.inject.Inject
 @HiltViewModel
 class EditViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
+    savedStateHandle: SavedStateHandle,
     private val getInnerProjectByIdUseCase: GetInnerProjectByIdUseCase,
     private val updateInnerProjectUseCase: UpdateInnerProjectUseCase,
     private val getInnerViewUseCase: GetInnerViewUseCase,
     private val getInnerViewContentUseCase: GetInnerViewContentUseCase,
     private val getInterviewGroupContentUseCase: GetInterviewGroupContentUseCase,
-    private val getInnerViewProjectByIdUseCase: GetInnerProjectByIdUseCase,
     private val playbackStateManager: PlaybackStateManager,
     private val playbackStateListener: PlaybackStateListener,
     val player: Player,
@@ -64,7 +67,10 @@ class EditViewModel @Inject constructor(
     init {
         playbackStateListener.attachTo(player)
 
+        val innerProjectId = savedStateHandle.toRoute<Route.Edit>().innerProjectId
+
         viewModelScope.launch {
+            fetchInnerProject(innerProjectId)
             playbackStateManager.flow.collect { playbackState ->
                 _editUiState.update {
                     it.copy(
@@ -81,28 +87,29 @@ class EditViewModel @Inject constructor(
         }
     }
 
-    fun fetchInnerProject(id: Int) {
-        viewModelScope.launch {
-            val innerProject = getInnerProjectByIdUseCase(id).first()
-            val duration = innerProject.innerProjectComponents.media.sumOf {
-                it.endPosition - it.startPosition
-            }
-            val media = innerProject.innerProjectComponents.media.map { mediaItem ->
-                MediaUiState(medium = mediaItem)
-            }
-            val accumulatedDurations =
-                calculateAccumulatedDurations(media)
-            _editUiState.update {
-                it.copy(
-                    innerProjectId = id,
-                    title = innerProject.title,
-                    duration = duration,
-                    media = media.toPersistentList(),
-                    accumulatedDurations = accumulatedDurations.toPersistentList(),
-                    subtitles = innerProject.innerProjectComponents.subtitles.toPersistentList(),
-                )
-            }
-            setMediaItems(innerProject.innerProjectComponents.media)
+    private suspend fun fetchInnerProject(id: Int) {
+        val innerProject = getInnerProjectByIdUseCase(id).first()
+        val duration = innerProject.innerProjectComponents.media.sumOf {
+            it.endPosition - it.startPosition
+        }
+        val media = innerProject.innerProjectComponents.media.map { mediaItem ->
+            MediaUiState(medium = mediaItem)
+        }
+        val accumulatedDurations =
+            calculateAccumulatedDurations(media)
+
+        setMediaItems(innerProject.innerProjectComponents.media)
+
+        _editUiState.update {
+            it.copy(
+                innerProjectId = id,
+                isRecording = innerProject.isRecording,
+                title = innerProject.title,
+                duration = duration,
+                media = media.toPersistentList(),
+                accumulatedDurations = accumulatedDurations.toPersistentList(),
+                subtitles = innerProject.innerProjectComponents.subtitles.toPersistentList(),
+            )
         }
     }
 

--- a/feature/edit/src/main/java/com/dev/innerview/feature/edit/model/EditUiState.kt
+++ b/feature/edit/src/main/java/com/dev/innerview/feature/edit/model/EditUiState.kt
@@ -13,6 +13,7 @@ import java.time.ZonedDateTime
 @Immutable
 data class EditUiState(
     val innerProjectId: Int = 0,
+    val isRecording: Boolean = false,
     val title: String = "",
     val isPlaying: Boolean = false,
     val currentMediaItemIndex: Int = 0,

--- a/feature/edit/src/main/java/com/dev/innerview/feature/edit/navigation/EditNavigation.kt
+++ b/feature/edit/src/main/java/com/dev/innerview/feature/edit/navigation/EditNavigation.kt
@@ -34,10 +34,8 @@ fun NavGraphBuilder.editNavGraph(
         )
     }
 
-    composable<Route.Edit> { navBackStackEntry ->
-        val (innerProjectId) = navBackStackEntry.toRoute<Route.Edit>()
+    composable<Route.Edit> {
         EditScreen(
-            innerProjectId = innerProjectId,
             onShowErrorSnackBar = onShowErrorSnackBar,
             onBackClick = onBackClick
         )

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/InnerViewDetailScreen.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/InnerViewDetailScreen.kt
@@ -70,7 +70,6 @@ import java.time.format.DateTimeFormatter
 @Composable
 internal fun InnerViewDetailScreen(
     padding: PaddingValues,
-    innerViewId: String,
     onBackClick: () -> Unit,
     onShowToast: (text: String) -> Unit,
     navigateToInterviewGroup: (String, Int) -> Unit,
@@ -80,10 +79,6 @@ internal fun InnerViewDetailScreen(
 ) {
     val uiState by viewModel.innerViewDetailUiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
-
-    LaunchedEffect(innerViewId) {
-        viewModel.fetchInnerView(innerViewId)
-    }
 
     LaunchedEffect(Unit) {
         viewModel.uiEventFlow.collectLatest { event ->
@@ -119,23 +114,21 @@ internal fun InnerViewDetailScreen(
 
     InnerViewDetailContent(
         padding = padding,
-        innerViewId = innerViewId,
         uiState = uiState,
         onBackClick = onBackClick,
         onClickInterviewGroup = { isRecording, id ->
-            if (isRecording) navigateToRecord(innerViewId, id)
-            else navigateToInterviewGroup(innerViewId, id)
+            if (isRecording) navigateToRecord(uiState.innerViewId, id)
+            else navigateToInterviewGroup(uiState.innerViewId, id)
         },
-        onNotificationClick = { isOn -> viewModel.changeNotificationState(innerViewId, isOn) },
+        onNotificationClick = viewModel::changeNotificationState,
         navigateToInnerViewQuestion = navigateToInnerViewQuestion,
-        addInterviewGroup = { viewModel.addInnerViewGroup(innerViewId) }
+        addInterviewGroup = viewModel::addInnerViewGroup
     )
 }
 
 @Composable
 private fun InnerViewDetailContent(
     padding: PaddingValues,
-    innerViewId: String,
     uiState: InnerViewDetailUiState,
     onBackClick: () -> Unit,
     onClickInterviewGroup: (Boolean, Int) -> Unit,
@@ -156,7 +149,7 @@ private fun InnerViewDetailContent(
                 InnerViewAppBarIcon(
                     imageVector = Icons.AutoMirrored.Filled.List,
                     navigationIconContentDescription = null,
-                    onClick = { navigateToInnerViewQuestion(innerViewId) }
+                    onClick = { navigateToInnerViewQuestion(uiState.innerViewId) }
                 )
                 InnerViewAppBarIcon(
                     imageVector =
@@ -337,7 +330,6 @@ private fun InterviewGroupList(
 private fun InnerViewDetailContentPreview() {
     InnerViewTheme {
         InnerViewDetailContent(
-            innerViewId = "",
             uiState = InnerViewDetailUiState(
                 title = "title",
                 interviewGroups = persistentListOf(
@@ -380,7 +372,6 @@ private fun InnerViewDetailContentPreview() {
 private fun DailyInnerViewDetailContentPreview() {
     InnerViewTheme {
         InnerViewDetailContent(
-            innerViewId = "",
             uiState = InnerViewDetailUiState(
                 title = "title",
                 type = InnerViewType.DAY,

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/InnerViewDetailViewModel.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/InnerViewDetailViewModel.kt
@@ -1,7 +1,9 @@
 package com.dev.innerview.feature.home
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.dev.innerview.core.domain.usecase.AddInterviewGroupUseCase
 import com.dev.innerview.core.domain.usecase.CancelNotificationAlarmUseCase
 import com.dev.innerview.core.domain.usecase.ChangeInnerViewNotificationUseCase
@@ -9,6 +11,7 @@ import com.dev.innerview.core.domain.usecase.GetInnerViewContentUseCase
 import com.dev.innerview.core.domain.usecase.RegisterNotificationAlarmUseCase
 import com.dev.innerview.core.model.InnerViewType
 import com.dev.innerview.core.model.InterviewGroup
+import com.dev.innerview.core.navigation.Route
 import com.dev.innerview.feature.home.model.InnerViewDetailUiEvent
 import com.dev.innerview.feature.home.model.InnerViewDetailUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -27,7 +30,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class InnerViewDetailViewModel @Inject constructor(
-    private val getInnerViewContentUseCase: GetInnerViewContentUseCase,
+    savedStateHandle: SavedStateHandle,
+    getInnerViewContentUseCase: GetInnerViewContentUseCase,
     private val addInterviewGroupUseCase: AddInterviewGroupUseCase,
     private val changeInnerViewNotificationUseCase: ChangeInnerViewNotificationUseCase,
     private val registerNotificationAlarmUseCase: RegisterNotificationAlarmUseCase,
@@ -43,7 +47,8 @@ class InnerViewDetailViewModel @Inject constructor(
     private val _innerViewDetailUiState = MutableStateFlow(InnerViewDetailUiState())
     val innerViewDetailUiState = _innerViewDetailUiState.asStateFlow()
 
-    fun fetchInnerView(innerViewId: String) {
+    init {
+        val innerViewId = savedStateHandle.toRoute<Route.InnerViewDetail>().id
         getInnerViewContentUseCase(innerViewId)
             .onEach { innerViewContent ->
                 val reactivateAt = findReactivateDate(
@@ -52,6 +57,7 @@ class InnerViewDetailViewModel @Inject constructor(
                 )
                 _innerViewDetailUiState.update {
                     it.copy(
+                        innerViewId = innerViewId,
                         title = innerViewContent.innerView.title,
                         type = innerViewContent.innerView.type,
                         interviewGroups = innerViewContent.interviewGroups.toPersistentList(),
@@ -82,13 +88,13 @@ class InnerViewDetailViewModel @Inject constructor(
         }
     }
 
-    fun changeNotificationState(innerViewId: String, isOn: Boolean) {
+    fun changeNotificationState(isOn: Boolean) {
         viewModelScope.launch {
-            changeInnerViewNotificationUseCase(innerViewId, isOn)
+            changeInnerViewNotificationUseCase(_innerViewDetailUiState.value.innerViewId, isOn)
             if (isOn) {
                 with(innerViewDetailUiState.value) {
                     registerNotificationAlarmUseCase(
-                        innerViewId = innerViewId,
+                        innerViewId = _innerViewDetailUiState.value.innerViewId,
                         innerViewType = type,
                         innerViewTitle = title,
                         lastInnerViewTime = interviewGroups
@@ -98,16 +104,16 @@ class InnerViewDetailViewModel @Inject constructor(
                     )
                 }
             } else {
-                cancelNotificationAlarmUseCase(innerViewId)
+                cancelNotificationAlarmUseCase(_innerViewDetailUiState.value.innerViewId)
             }
             _uiEventFlow.emit(InnerViewDetailUiEvent.TurnNotificationEvent(isOn))
         }
     }
 
-    fun addInnerViewGroup(innerViewId: String) {
+    fun addInnerViewGroup() {
         viewModelScope.launch {
             addInterviewGroupUseCase(
-                innerViewId,
+                _innerViewDetailUiState.value.innerViewId,
                 _innerViewDetailUiState.value.type != InnerViewType.DAY
             )
         }

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/InnerViewQuestionScreen.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/InnerViewQuestionScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -50,15 +49,10 @@ import kotlin.math.roundToInt
 @Composable
 internal fun InnerViewQuestionScreen(
     padding: PaddingValues,
-    innerViewId: String,
     onBackClick: () -> Unit,
     viewModel: InnerViewQuestionViewModel = hiltViewModel()
 ) {
     val innerViewQuestionUiState by viewModel.innerViewQuestionUiState.collectAsStateWithLifecycle()
-
-    LaunchedEffect(innerViewId) {
-        viewModel.fetchInnerViewQuestions(innerViewId)
-    }
 
     InnerViewQuestionContent(
         padding = padding,
@@ -66,7 +60,7 @@ internal fun InnerViewQuestionScreen(
         title = innerViewQuestionUiState.title,
         questions = innerViewQuestionUiState.interviewQuestions,
         updateQuestions = { oldIndex, newIndex ->
-            viewModel.updateQuestions(innerViewId, oldIndex, newIndex)
+            viewModel.updateQuestions(oldIndex, newIndex)
         }
     )
 }

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/InnerViewQuestionViewModel.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/InnerViewQuestionViewModel.kt
@@ -1,9 +1,12 @@
 package com.dev.innerview.feature.home
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.dev.innerview.core.domain.usecase.GetInnerViewContentUseCase
 import com.dev.innerview.core.domain.usecase.ReorderQuestionsUseCase
+import com.dev.innerview.core.navigation.Route
 import com.dev.innerview.feature.home.model.InnerViewQuestionUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
@@ -18,6 +21,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class InnerViewQuestionViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val getInnerViewContentUseCase: GetInnerViewContentUseCase,
     private val reorderQuestionsUseCase: ReorderQuestionsUseCase
 ) : ViewModel() {
@@ -28,11 +32,13 @@ class InnerViewQuestionViewModel @Inject constructor(
     private val _innerViewQuestionUiState = MutableStateFlow(InnerViewQuestionUiState())
     val innerViewQuestionUiState = _innerViewQuestionUiState.asStateFlow()
 
-    fun fetchInnerViewQuestions(innerViewId: String) {
+    init {
+        val innerViewId = savedStateHandle.toRoute<Route.InnerViewQuestion>().id
         viewModelScope.launch {
             val innerViewContent = getInnerViewContentUseCase(innerViewId).first()
             _innerViewQuestionUiState.update {
                 it.copy(
+                    innerViewId = innerViewId,
                     title = innerViewContent.innerView.title,
                     interviewQuestions = innerViewContent.innerView.questions.toPersistentList()
                 )
@@ -40,12 +46,12 @@ class InnerViewQuestionViewModel @Inject constructor(
         }
     }
 
-    fun updateQuestions(innerViewId: String, oldIndex: Int, newIndex: Int) {
+    fun updateQuestions(oldIndex: Int, newIndex: Int) {
         reorderQuestions(oldIndex, newIndex)
         viewModelScope.launch {
             runCatching {
                 reorderQuestionsUseCase(
-                    innerViewId,
+                    _innerViewQuestionUiState.value.innerViewId,
                     oldIndex,
                     newIndex
                 )

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/InterviewGroupScreen.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/InterviewGroupScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,17 +42,11 @@ import kotlinx.collections.immutable.persistentListOf
 @Composable
 internal fun InterviewGroupScreen(
     padding: PaddingValues,
-    innerViewId: String,
-    interviewGroupId: Int,
     onBackClick: () -> Unit,
     navigateToPlayer: () -> Unit,
     viewModel: InterviewGroupViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.interviewGroupUiState.collectAsStateWithLifecycle()
-
-    LaunchedEffect(innerViewId) {
-        viewModel.fetchInterviewGroup(innerViewId, interviewGroupId)
-    }
 
     InterviewGroupContent(
         uiState = uiState,

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/InterviewGroupViewModel.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/InterviewGroupViewModel.kt
@@ -1,9 +1,11 @@
 package com.dev.innerview.feature.home
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.dev.innerview.core.domain.usecase.GetInterviewGroupContentUseCase
-import com.dev.innerview.core.model.InterviewGroupContent
+import com.dev.innerview.core.navigation.Route
 import com.dev.innerview.feature.home.model.InterviewGroupUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
@@ -18,6 +20,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class InterviewGroupViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val getInterviewGroupContentUseCase: GetInterviewGroupContentUseCase
 ) : ViewModel() {
 
@@ -27,11 +30,14 @@ class InterviewGroupViewModel @Inject constructor(
     private val _interviewGroupUiState = MutableStateFlow(InterviewGroupUiState())
     val interviewGroupUiState get() = _interviewGroupUiState.asStateFlow()
 
-    fun fetchInterviewGroup(innerViewId: String, interviewGroupId: Int) {
+    init {
+        val (innerViewId, interviewGroupId) = savedStateHandle.toRoute<Route.InterviewGroup>()
         getInterviewGroupContentUseCase(innerViewId, interviewGroupId)
             .onEach { interviewGroupContent ->
                 _interviewGroupUiState.update {
                     it.copy(
+                        innerViewId = innerViewId,
+                        interviewGroupId = interviewGroupId,
                         title = interviewGroupContent.innerView.title,
                         createdAt = interviewGroupContent.interviewGroup.createdAt,
                         interviews = interviewGroupContent.interviews.toPersistentList()

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/model/InnerViewDetailUiState.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/model/InnerViewDetailUiState.kt
@@ -9,6 +9,7 @@ import java.time.LocalDate
 
 @Immutable
 data class InnerViewDetailUiState(
+    val innerViewId: String = "",
     val title: String = "",
     val type: InnerViewType = InnerViewType.YEAR,
     val interviewGroups: ImmutableList<InterviewGroup> = persistentListOf(),

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/model/InnerViewQuestionUiState.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/model/InnerViewQuestionUiState.kt
@@ -6,6 +6,7 @@ import kotlinx.collections.immutable.persistentListOf
 
 @Immutable
 data class InnerViewQuestionUiState(
+    val innerViewId: String = "",
     val title: String = "",
     val interviewQuestions: ImmutableList<String> = persistentListOf()
 )

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/model/InterviewGroupUiState.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/model/InterviewGroupUiState.kt
@@ -8,6 +8,8 @@ import java.time.ZonedDateTime
 
 @Immutable
 data class InterviewGroupUiState(
+    val innerViewId: String = "",
+    val interviewGroupId: Int = 0,
     val title: String = "",
     val createdAt: ZonedDateTime = ZonedDateTime.now(),
     val interviews: ImmutableList<Interview> = persistentListOf()

--- a/feature/home/src/main/java/com/dev/innerview/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/dev/innerview/feature/home/navigation/HomeNavigation.kt
@@ -6,7 +6,6 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.navDeepLink
-import androidx.navigation.toRoute
 import com.dev.innerview.core.navigation.DEEP_LINK_BASE_PATH
 import com.dev.innerview.core.navigation.MainTabRoute
 import com.dev.innerview.core.navigation.Route
@@ -56,11 +55,9 @@ fun NavGraphBuilder.homeNavGraph(
 
     composable<Route.InnerViewDetail>(
         deepLinks = listOf(navDeepLink<Route.InnerViewDetail>(basePath = DEEP_LINK_BASE_PATH))
-    ) { navBackStackEntry ->
-        val (id) = navBackStackEntry.toRoute<Route.InnerViewDetail>()
+    ) {
         InnerViewDetailScreen(
             padding = padding,
-            innerViewId = id,
             onBackClick = onBackClick,
             onShowToast = onShowToast,
             navigateToInterviewGroup = navigateToInterviewGroup,
@@ -69,22 +66,17 @@ fun NavGraphBuilder.homeNavGraph(
         )
     }
 
-    composable<Route.InterviewGroup> { navBackStackEntry ->
-        val (innerViewId, interviewGroupId) = navBackStackEntry.toRoute<Route.InterviewGroup>()
+    composable<Route.InterviewGroup> {
         InterviewGroupScreen(
             padding = padding,
             onBackClick = onBackClick,
-            innerViewId = innerViewId,
-            interviewGroupId = interviewGroupId,
             navigateToPlayer = navigateToPlayer
         )
     }
 
-    composable<Route.InnerViewQuestion> { navBackStackEntry ->
-        val (id) = navBackStackEntry.toRoute<Route.InnerViewQuestion>()
+    composable<Route.InnerViewQuestion> {
         InnerViewQuestionScreen(
             padding = padding,
-            innerViewId = id,
             onBackClick = onBackClick
         )
     }

--- a/feature/main/src/main/java/com/dev/innerview/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/dev/innerview/feature/main/MainScreen.kt
@@ -40,12 +40,12 @@ internal fun MainScreen(
             snackBarHostState.showSnackbar(
                 when (throwable) {  // throwable 타입 별 snackBar 처리
                     is IllegalArgumentException -> throwable.message ?: unknownErrorMessage
-                    else -> unknownErrorMessage
+                    else -> throwable?.message ?: unknownErrorMessage
                 }
             )
         }
     }
-    val onShowToast:(text:String) -> Unit = { text -> showToast(context, text) }
+    val onShowToast: (text: String) -> Unit = { text -> showToast(context, text) }
 
     MainScreenContent(
         navigator = navigator,

--- a/feature/record/src/main/java/com/dev/innerview/feature/record/FilmingScreen.kt
+++ b/feature/record/src/main/java/com/dev/innerview/feature/record/FilmingScreen.kt
@@ -54,9 +54,6 @@ import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 internal fun FilmingScreen(
-    innerViewId: String,
-    interviewGroupId: Int,
-    question: String,
     padding: PaddingValues,
     onBackClick: () -> Unit,
     navigationToEdit: (Int) -> Unit,
@@ -117,7 +114,6 @@ internal fun FilmingScreen(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.fetchFilmingUiState(innerViewId, interviewGroupId, question)
         viewModel.uiEventFlow.collectLatest { event ->
             when (event) {
                 is FilmingUiEvent.NavigateToEdit -> {
@@ -129,10 +125,9 @@ internal fun FilmingScreen(
 
     FilmingContent(
         filmingUiState = filmingUiState,
-        question = question,
         padding = padding,
         onBackClick = onBackClick,
-        addInnerProject = { viewModel.addInnerProject(innerViewId, interviewGroupId, question, it) },
+        addInnerProject = { viewModel.addInnerProject(it) },
         startRecording = viewModel::startRecording,
         resetRecording = viewModel::resetRecording,
         pauseRecording = viewModel::pauseRecording,
@@ -162,7 +157,6 @@ internal fun FilmingScreen(
 @Composable
 private fun FilmingContent(
     filmingUiState: FilmingUiState,
-    question: String,
     padding: PaddingValues,
     onBackClick: () -> Unit,
     onGoToAppSettings: () -> Unit,
@@ -181,7 +175,6 @@ private fun FilmingContent(
     if (filmingUiState.isSheetOpen) {
         PrevInterviewBottomSheet(
             filmingUiState = filmingUiState,
-            question = question,
             sheetState = sheetState,
             onDismissRequest = selectBottomSheet,
             onItemClick = {}
@@ -194,7 +187,7 @@ private fun FilmingContent(
             .fillMaxSize()
     ) {
         InnerViewTopAppBar(
-            title = question,
+            title = filmingUiState.question,
             navigationType = TopAppBarNavigationType.Back,
             onNavigationClick = onBackClick,
         )
@@ -259,7 +252,6 @@ private fun FilmingContentPreview() {
             filmingUiState = FilmingUiState(
                 permissionState = PermissionState.Granted,
             ),
-            question = "question",
             padding = PaddingValues(),
             onBackClick = {},
             onGoToAppSettings = {},

--- a/feature/record/src/main/java/com/dev/innerview/feature/record/FilmingViewModel.kt
+++ b/feature/record/src/main/java/com/dev/innerview/feature/record/FilmingViewModel.kt
@@ -1,12 +1,15 @@
 package com.dev.innerview.feature.record
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.dev.innerview.core.domain.usecase.AddInnerProjectUseCase
 import com.dev.innerview.core.domain.usecase.GetInterviewByQuestionUseCase
 import com.dev.innerview.core.model.InnerProjectComponents
 import com.dev.innerview.core.model.InterviewPiece
 import com.dev.innerview.core.model.RecordState
+import com.dev.innerview.core.navigation.Route
 import com.dev.innerview.feature.record.model.FilmingUiEvent
 import com.dev.innerview.feature.record.model.FilmingUiState
 import com.dev.innerview.feature.record.model.PermissionState
@@ -26,6 +29,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class FilmingViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val addInnerProjectUseCase: AddInnerProjectUseCase,
     private val getInterviewByQuestionUseCase: GetInterviewByQuestionUseCase
 ) : ViewModel() {
@@ -39,11 +43,15 @@ class FilmingViewModel @Inject constructor(
     private val _filmingUiState = MutableStateFlow(FilmingUiState())
     val filmingUiState = _filmingUiState.asStateFlow()
 
-    fun fetchFilmingUiState(innerViewId: String, interviewGroupId: Int, question: String) {
+    init {
+        val (innerViewId, interviewGroupId, question) = savedStateHandle.toRoute<Route.Filming>()
         getInterviewByQuestionUseCase(innerViewId, question)
             .onEach { interviews ->
                 _filmingUiState.update {
                     it.copy(
+                        innerViewId = innerViewId,
+                        interviewGroupId = interviewGroupId,
+                        question = question,
                         outputFileName = sha256(innerViewId + interviewGroupId + question) + ".mp4",
                         interviews = interviews.toPersistentList()
                     )
@@ -51,14 +59,14 @@ class FilmingViewModel @Inject constructor(
             }.launchIn(viewModelScope)
     }
 
-    fun addInnerProject(innerViewId: String, interviewGroupId: Int, question: String, duration: Long) {
+    fun addInnerProject(duration: Long) {
         viewModelScope.launch {
             runCatching {
                 val innerProjectId = addInnerProjectUseCase(
-                    question,
-                    innerViewId,
-                    interviewGroupId,
-                    InnerProjectComponents(
+                    title = _filmingUiState.value.question,
+                    innerViewId = _filmingUiState.value.innerViewId,
+                    interviewGroupId = _filmingUiState.value.interviewGroupId,
+                    innerProjectComponents = InnerProjectComponents(
                         media = listOf(
                             InterviewPiece(
                                 filePath = "interviews/${_filmingUiState.value.outputFileName}",

--- a/feature/record/src/main/java/com/dev/innerview/feature/record/RecordScreen.kt
+++ b/feature/record/src/main/java/com/dev/innerview/feature/record/RecordScreen.kt
@@ -55,8 +55,6 @@ import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 internal fun RecordScreen(
-    innerViewId: String,
-    interviewGroupId: Int,
     padding: PaddingValues,
     onBackClick: () -> Unit,
     onShowErrorSnackBar: (throwable: Throwable?) -> Unit,
@@ -95,33 +93,39 @@ internal fun RecordScreen(
                 }
 
                 is RecordUiEvent.NavigateToFilming -> {
-                    navigateToFilming(innerViewId, interviewGroupId, event.question)
+                    navigateToFilming(
+                        recordUiState.innerViewId,
+                        recordUiState.interviewGroupId,
+                        event.question
+                    )
                 }
             }
         }
-    }
-
-    LaunchedEffect(innerViewId, interviewGroupId) {
-        viewModel.fetchInterviewGroup(innerViewId, interviewGroupId)
     }
 
     RecordContent(
         recordUiState = recordUiState,
         padding = padding,
         onBackClick = onBackClick,
-        selectQuestionAdd = { viewModel.selectQuestionAdd() },
-        updateCustomQuestion = { viewModel.updateCustomQuestion(it) },
-        updateDialogSelectedType = { viewModel.updateDialogSelectedType(it) },
-        addQuestion = { viewModel.addQuestion(innerViewId, interviewGroupId) },
-        navigateToFilming = { navigateToFilming(innerViewId, interviewGroupId, it) },
-        navigationToEdit = { navigationToEdit(it) },
-        completeInterviewGroup = { viewModel.completeInterviewGroup(innerViewId, interviewGroupId) },
-        onSelectInterviewDropdown = { viewModel.selectInterviewDropdown(it) },
-        onSelectQuestionDelete = { viewModel.selectQuestionDelete(it) },
-        onSelectInnerProjectDelete = { viewModel.selectInnerProjectDelete(it) },
-        deleteQuestion = { viewModel.deleteQuestion(innerViewId, interviewGroupId, it) },
-        deleteInnerProject = { viewModel.deleteInnerProject(innerViewId, interviewGroupId, it) },
-        onRefreshQuestion = { viewModel.updateRecommendQuestions() }
+        selectQuestionAdd = viewModel::selectQuestionAdd,
+        updateCustomQuestion = viewModel::updateCustomQuestion,
+        updateDialogSelectedType = viewModel::updateDialogSelectedType,
+        addQuestion = viewModel::addQuestion,
+        navigateToFilming = {
+            navigateToFilming(
+                recordUiState.innerViewId,
+                recordUiState.interviewGroupId,
+                it
+            )
+        },
+        navigationToEdit = navigationToEdit,
+        completeInterviewGroup = viewModel::completeInterviewGroup,
+        onSelectInterviewDropdown = viewModel::selectInterviewDropdown,
+        onSelectQuestionDelete = viewModel::selectQuestionDelete,
+        onSelectInnerProjectDelete = viewModel::selectInnerProjectDelete,
+        deleteQuestion = viewModel::deleteQuestion,
+        deleteInnerProject = viewModel::deleteInnerProject,
+        onRefreshQuestion = viewModel::updateRecommendQuestions
     )
 }
 

--- a/feature/record/src/main/java/com/dev/innerview/feature/record/RecordViewModel.kt
+++ b/feature/record/src/main/java/com/dev/innerview/feature/record/RecordViewModel.kt
@@ -1,7 +1,9 @@
 package com.dev.innerview.feature.record
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.dev.innerview.core.domain.usecase.AddQuestionUseCase
 import com.dev.innerview.core.domain.usecase.CancelNotificationAlarmUseCase
 import com.dev.innerview.core.domain.usecase.CompleteInterviewGroupUseCase
@@ -11,6 +13,7 @@ import com.dev.innerview.core.domain.usecase.GetInterviewGroupContentUseCase
 import com.dev.innerview.core.domain.usecase.GetRecommendQuestionsByTypeUseCase
 import com.dev.innerview.core.domain.usecase.RegisterNotificationAlarmUseCase
 import com.dev.innerview.core.model.InnerViewType
+import com.dev.innerview.core.navigation.Route
 import com.dev.innerview.feature.record.model.InterviewItemUiState
 import com.dev.innerview.feature.record.model.RecordUiEvent
 import com.dev.innerview.feature.record.model.RecordUiState
@@ -29,6 +32,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class RecordViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val getInterviewGroupContentUseCase: GetInterviewGroupContentUseCase,
     private val addQuestionUseCase: AddQuestionUseCase,
     private val completeInterviewGroupUseCase: CompleteInterviewGroupUseCase,
@@ -51,11 +55,14 @@ class RecordViewModel @Inject constructor(
     private val _recordUiState = MutableStateFlow(RecordUiState())
     val recordUiState = _recordUiState.asStateFlow()
 
-    fun fetchInterviewGroup(innerViewId: String, interviewGroupId: Int) {
+    init {
+        val (innerViewId, interviewGroupId) = savedStateHandle.toRoute<Route.Records>()
         getInterviewGroupContentUseCase(innerViewId, interviewGroupId)
             .onEach { interviewGroupContent ->
                 _recordUiState.update {
                     it.copy(
+                        innerViewId = innerViewId,
+                        interviewGroupId = interviewGroupId,
                         title = interviewGroupContent.innerView.title,
                         type = interviewGroupContent.innerView.type,
                         createdAt = interviewGroupContent.interviewGroup.createdAt,
@@ -78,12 +85,12 @@ class RecordViewModel @Inject constructor(
         }
     }
 
-    fun addQuestion(innerViewId: String, interviewGroupId: Int) {
+    fun addQuestion() {
         viewModelScope.launch {
             runCatching {
                 addQuestionUseCase(
-                    innerViewId,
-                    interviewGroupId,
+                    _recordUiState.value.innerViewId,
+                    _recordUiState.value.interviewGroupId,
                     _recordUiState.value.let {
                         it.selectableQuestions[it.selectedQuestion]
                     }
@@ -100,25 +107,36 @@ class RecordViewModel @Inject constructor(
         }
     }
 
-    fun deleteQuestion(innerViewId: String, interviewGroupId: Int, question: String) {
+    fun deleteQuestion(question: String) {
         viewModelScope.launch {
-            deleteQuestionUseCase(innerViewId, interviewGroupId, question)
+            deleteQuestionUseCase(
+                _recordUiState.value.innerViewId,
+                _recordUiState.value.interviewGroupId,
+                question
+            )
         }
     }
 
-    fun deleteInnerProject(innerViewId: String, interviewGroupId: Int, question: String) {
+    fun deleteInnerProject(question: String) {
         viewModelScope.launch {
-            deleteInnerProjectUseCase(innerViewId, interviewGroupId, question)
+            deleteInnerProjectUseCase(
+                _recordUiState.value.innerViewId,
+                _recordUiState.value.interviewGroupId,
+                question
+            )
         }
     }
 
-    fun completeInterviewGroup(innerViewId: String, interviewGroupId: Int) {
+    fun completeInterviewGroup() {
         viewModelScope.launch {
-            completeInterviewGroupUseCase(innerViewId, interviewGroupId)
-            cancelNotificationAlarmUseCase(innerViewId)
+            completeInterviewGroupUseCase(
+                _recordUiState.value.innerViewId,
+                _recordUiState.value.interviewGroupId
+            )
+            cancelNotificationAlarmUseCase(_recordUiState.value.innerViewId)
             with(recordUiState.value) {
                 registerNotificationAlarmUseCase(
-                    innerViewId = innerViewId,
+                    innerViewId = _recordUiState.value.innerViewId,
                     innerViewType = type,
                     innerViewTitle = title,
                     lastInnerViewTime = createdAt

--- a/feature/record/src/main/java/com/dev/innerview/feature/record/component/PrevInterviewBottomSheet.kt
+++ b/feature/record/src/main/java/com/dev/innerview/feature/record/component/PrevInterviewBottomSheet.kt
@@ -33,7 +33,6 @@ import java.time.ZonedDateTime
 @Composable
 fun PrevInterviewBottomSheet(
     filmingUiState: FilmingUiState,
-    question: String,
     sheetState: SheetState,
     onDismissRequest: () -> Unit,
     onItemClick: () -> Unit
@@ -51,7 +50,7 @@ fun PrevInterviewBottomSheet(
         ) {
             item {
                 Text(
-                    text = question,
+                    text = filmingUiState.question,
                     style = MaterialTheme.typography.titleSmall
                 )
                 Spacer(modifier = Modifier.size(20.dp))
@@ -98,7 +97,6 @@ private fun PrevInterviewBottomSheetPreview() {
                     Interview(createdAt = ZonedDateTime.now(), thumbnailVideoPath = "3"),
                 )
             ),
-            question = "question",
             sheetState = sheetState,
             onDismissRequest = {},
             onItemClick = {}

--- a/feature/record/src/main/java/com/dev/innerview/feature/record/model/FilmingUiState.kt
+++ b/feature/record/src/main/java/com/dev/innerview/feature/record/model/FilmingUiState.kt
@@ -9,6 +9,9 @@ import kotlinx.collections.immutable.persistentListOf
 
 @Immutable
 data class FilmingUiState(
+    val innerViewId: String = "",
+    val interviewGroupId: Int = 0,
+    val question: String = "",
     val permissionState: PermissionState = PermissionState.Loading,
     val isPermissionDialogVisible: Boolean = false,
     val outputFileName: String = "sample.mp4",

--- a/feature/record/src/main/java/com/dev/innerview/feature/record/model/RecordUiState.kt
+++ b/feature/record/src/main/java/com/dev/innerview/feature/record/model/RecordUiState.kt
@@ -8,6 +8,8 @@ import java.time.ZonedDateTime
 
 @Immutable
 data class RecordUiState(
+    val innerViewId: String = "",
+    val interviewGroupId: Int = 0,
     val title: String = "",
     val type: InnerViewType = InnerViewType.YEAR,
     val createdAt: ZonedDateTime = ZonedDateTime.now(),

--- a/feature/record/src/main/java/com/dev/innerview/feature/record/navigation/RecordNavigation.kt
+++ b/feature/record/src/main/java/com/dev/innerview/feature/record/navigation/RecordNavigation.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import androidx.navigation.toRoute
 import com.dev.innerview.core.navigation.Route
 import com.dev.innerview.feature.record.FilmingScreen
 import com.dev.innerview.feature.record.RecordScreen
@@ -25,11 +24,8 @@ fun NavGraphBuilder.recordNavGraph(
     navigateToEdit: (Int) -> Unit
 ) {
 
-    composable<Route.Records> { navBackStackEntry ->
-        val (innerViewId, interviewGroupId) = navBackStackEntry.toRoute<Route.Records>()
+    composable<Route.Records> {
         RecordScreen(
-            innerViewId = innerViewId,
-            interviewGroupId = interviewGroupId,
             padding = padding,
             onBackClick = onBackClick,
             onShowErrorSnackBar = onShowErrorSnackBar,
@@ -38,12 +34,8 @@ fun NavGraphBuilder.recordNavGraph(
         )
     }
 
-    composable<Route.Filming> { navBackStackEntry ->
-        val (innerViewId, interviewGroupId, question) = navBackStackEntry.toRoute<Route.Filming>()
+    composable<Route.Filming> {
         FilmingScreen(
-            innerViewId = innerViewId,
-            interviewGroupId = interviewGroupId,
-            question = question,
             padding = padding,
             onBackClick = onBackClick,
             navigationToEdit = navigateToEdit,


### PR DESCRIPTION
## 개요
- savedStateHandle을 사용한 navigation 인자 전달 수정
- Thowable에서 Error 타입이 없을 때, message 처리하여 스낵바 출력 설정

- 인터뷰 촬영 중, 편집 화면 진입 시 분기 처리
  - 촬영 중일 경우, 완료 버튼 / 프로젝트 편집일 경우, 다운로드 버튼
  - 촬영 중일 경우, 다른 미디어 추가 불가

## 스크린샷

![image](https://github.com/user-attachments/assets/63155780-253c-4aa9-9b3d-ae0ea6f0124e)
![image](https://github.com/user-attachments/assets/204d9976-4611-470f-94f4-f5845c298d66)
