### PR TITLE
IV-80 프로젝트 삭제 기능

### DIFF
--- a/core/data-api/src/main/java/com/dev/innerview/core/data_api/InnerViewRepository.kt
+++ b/core/data-api/src/main/java/com/dev/innerview/core/data_api/InnerViewRepository.kt
@@ -78,6 +78,10 @@ interface InnerViewRepository {
         question: String,
     )
 
+    suspend fun deleteInnerProject(
+        innerProjectId: Int
+    )
+
     suspend fun completeInterviewGroup(
         innerViewId: String,
         interviewGroupId: Int

--- a/core/data/src/main/java/com/dev/innerview/core/data/repository/InnerViewRepositoryImpl.kt
+++ b/core/data/src/main/java/com/dev/innerview/core/data/repository/InnerViewRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.dev.innerview.core.data.repository
 
+import android.content.Context
 import com.dev.innerview.core.data.mapper.toData
 import com.dev.innerview.core.data_api.InnerViewRepository
 import com.dev.innerview.core.database.datasource.InnerViewDataSource
@@ -10,13 +11,16 @@ import com.dev.innerview.core.model.InnerViewContent
 import com.dev.innerview.core.model.InnerViewType
 import com.dev.innerview.core.model.Interview
 import com.dev.innerview.core.model.InterviewGroupContent
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import java.io.File
 import javax.inject.Inject
 
 class InnerViewRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val innerViewDataSource: InnerViewDataSource
 ) : InnerViewRepository {
 
@@ -90,7 +94,13 @@ class InnerViewRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteInnerView(id: String) {
-        innerViewDataSource.deleteInnerView(id)
+        val deleteInnerProjectContent = innerViewDataSource.deleteInnerView(id)
+        deleteInnerProjectContent.forEach { jsonData ->
+            val innerProjectComponents: InnerProjectComponents = Json.decodeFromString(jsonData)
+            innerProjectComponents.media.forEach {
+                File(context.filesDir, it.filePath).delete()
+            }
+        }
     }
 
     override suspend fun addInterviewGroup(innerViewId: String, addPrevQuestions: Boolean) {
@@ -102,7 +112,14 @@ class InnerViewRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteInterviewGroup(innerViewId: String, interviewGroupId: Int) {
-        innerViewDataSource.deleteInterviewGroup(innerViewId, interviewGroupId)
+        val deleteInnerProjectContent =
+            innerViewDataSource.deleteInterviewGroup(innerViewId, interviewGroupId)
+        deleteInnerProjectContent.forEach { jsonData ->
+            val innerProjectComponents: InnerProjectComponents = Json.decodeFromString(jsonData)
+            innerProjectComponents.media.forEach {
+                File(context.filesDir, it.filePath).delete()
+            }
+        }
     }
 
     override suspend fun addQuestion(
@@ -122,7 +139,14 @@ class InnerViewRepositoryImpl @Inject constructor(
         interviewGroupId: Int,
         question: String
     ) {
-        innerViewDataSource.deleteQuestion(innerViewId, interviewGroupId, question)
+        val deleteInnerProjectContent =
+            innerViewDataSource.deleteQuestion(innerViewId, interviewGroupId, question)
+        deleteInnerProjectContent.forEach { jsonData ->
+            val innerProjectComponents: InnerProjectComponents = Json.decodeFromString(jsonData)
+            innerProjectComponents.media.forEach {
+                File(context.filesDir, it.filePath).delete()
+            }
+        }
     }
 
     override suspend fun addInnerProject(
@@ -148,7 +172,14 @@ class InnerViewRepositoryImpl @Inject constructor(
         interviewGroupId: Int,
         question: String
     ) {
-        innerViewDataSource.deleteInnerProject(innerViewId, interviewGroupId, question)
+        val deleteInnerProjectContent =
+            innerViewDataSource.deleteInnerProject(innerViewId, interviewGroupId, question)
+        deleteInnerProjectContent.forEach { jsonData ->
+            val innerProjectComponents: InnerProjectComponents = Json.decodeFromString(jsonData)
+            innerProjectComponents.media.forEach {
+                File(context.filesDir, it.filePath).delete()
+            }
+        }
     }
 
     override suspend fun deleteInnerProject(innerProjectId: Int) {

--- a/core/data/src/main/java/com/dev/innerview/core/data/repository/InnerViewRepositoryImpl.kt
+++ b/core/data/src/main/java/com/dev/innerview/core/data/repository/InnerViewRepositoryImpl.kt
@@ -151,6 +151,10 @@ class InnerViewRepositoryImpl @Inject constructor(
         innerViewDataSource.deleteInnerProject(innerViewId, interviewGroupId, question)
     }
 
+    override suspend fun deleteInnerProject(innerProjectId: Int) {
+        innerViewDataSource.deleteInnerProject(innerProjectId)
+    }
+
     override suspend fun completeInterviewGroup(innerViewId: String, interviewGroupId: Int) {
         innerViewDataSource.completeInterviewGroup(innerViewId, interviewGroupId)
     }

--- a/core/database/src/main/java/com/dev/innerview/core/database/datasource/InnerViewDataSource.kt
+++ b/core/database/src/main/java/com/dev/innerview/core/database/datasource/InnerViewDataSource.kt
@@ -67,18 +67,23 @@ class InnerViewDataSource @Inject constructor(
         }
     }
 
-    suspend fun deleteInnerView(id: String) {
+    suspend fun deleteInnerView(id: String): List<String> {
+        val deleteInnerProjectContent = mutableListOf<String>()
         realm.write {
             val innerView = query<InnerViewSchema>("_id == $0", id).find().first()
 
             innerView.interviewGroups.forEach { interviewGroup ->
                 interviewGroup.interviews.forEach { interview ->
-                    interview.innerProject?.let { delete(it) }
+                    interview.innerProject?.let {
+                        deleteInnerProjectContent.add(it.jsonData)
+                        delete(it)
+                    }
                 }
             }
 
             delete(innerView)
         }
+        return deleteInnerProjectContent
     }
 
     suspend fun addInterviewGroup(innerViewId: String, addPrevQuestions: Boolean = true) {
@@ -119,17 +124,22 @@ class InnerViewDataSource @Inject constructor(
     suspend fun deleteInterviewGroup(
         innerViewId: String,
         interviewGroupId: Int,
-    ) {
+    ): List<String> {
+        val deleteInnerProjectContent = mutableListOf<String>()
         realm.write {
             val interviewGroup = query<InnerViewSchema>("_id == $0", innerViewId).find().first()
                 .interviewGroups.first { it.id == interviewGroupId }
 
             interviewGroup.interviews.forEach { interview ->
-                interview.innerProject?.let { delete(it) }
+                interview.innerProject?.let {
+                    deleteInnerProjectContent.add(it.jsonData)
+                    delete(it)
+                }
             }
 
             delete(interviewGroup)
         }
+        return deleteInnerProjectContent
     }
 
     suspend fun addQuestion(
@@ -175,7 +185,8 @@ class InnerViewDataSource @Inject constructor(
         innerViewId: String,
         interviewGroupId: Int,
         question: String
-    ) {
+    ): List<String> {
+        val deleteInnerProjectContent = mutableListOf<String>()
         realm.write {
             val innerView = query<InnerViewSchema>("_id == $0", innerViewId).find().first()
 
@@ -183,10 +194,14 @@ class InnerViewDataSource @Inject constructor(
                 .interviews.first { it.question == question }
 
             if (!interview.isRequired) {
-                interview.innerProject?.let { delete(it) }
+                interview.innerProject?.let {
+                    deleteInnerProjectContent.add(it.jsonData)
+                    delete(it)
+                }
                 delete(interview)
             }
         }
+        return deleteInnerProjectContent
     }
 
     suspend fun addInnerProject(
@@ -243,15 +258,20 @@ class InnerViewDataSource @Inject constructor(
         innerViewId: String,
         interviewGroupId: Int,
         question: String,
-    ) {
+    ): List<String> {
+        val deleteInnerProjectContent = mutableListOf<String>()
         realm.write {
             val innerView = query<InnerViewSchema>("_id == $0", innerViewId).find().first()
 
             val innerProject = innerView.interviewGroups.first { it.id == interviewGroupId }
                 .interviews.first { it.question == question }.innerProject
 
-            innerProject?.let { delete(it) }
+            innerProject?.let {
+                deleteInnerProjectContent.add(it.jsonData)
+                delete(it)
+            }
         }
+        return deleteInnerProjectContent
     }
 
     suspend fun deleteInnerProject(innerProjectId: Int) {

--- a/core/database/src/main/java/com/dev/innerview/core/database/datasource/InnerViewDataSource.kt
+++ b/core/database/src/main/java/com/dev/innerview/core/database/datasource/InnerViewDataSource.kt
@@ -108,7 +108,7 @@ class InnerViewDataSource @Inject constructor(
         }
     }
 
-    suspend fun changeInnerViewNotification(innerViewId:String, isOn:Boolean) {
+    suspend fun changeInnerViewNotification(innerViewId: String, isOn: Boolean) {
         realm.write {
             val innerView = query<InnerViewSchema>("_id == $0", innerViewId).find().first()
 
@@ -250,6 +250,14 @@ class InnerViewDataSource @Inject constructor(
             val innerProject = innerView.interviewGroups.first { it.id == interviewGroupId }
                 .interviews.first { it.question == question }.innerProject
 
+            innerProject?.let { delete(it) }
+        }
+    }
+
+    suspend fun deleteInnerProject(innerProjectId: Int) {
+        realm.write {
+            val innerProject =
+                query<InnerProjectSchema>("_id == $0", innerProjectId).find().firstOrNull()
             innerProject?.let { delete(it) }
         }
     }

--- a/core/domain/src/main/java/com/dev/innerview/core/domain/usecase/DeleteInnerProjectUseCase.kt
+++ b/core/domain/src/main/java/com/dev/innerview/core/domain/usecase/DeleteInnerProjectUseCase.kt
@@ -11,4 +11,8 @@ class DeleteInnerProjectUseCase @Inject constructor(
         interviewGroupId: Int,
         question: String
     ) = innerViewRepository.deleteInnerProject(innerViewId, interviewGroupId, question)
+
+    suspend operator fun invoke(
+        innerProjectId: Int
+    ) = innerViewRepository.deleteInnerProject(innerProjectId)
 }

--- a/feature/edit/src/main/java/com/dev/innerview/feature/edit/EditHomeScreen.kt
+++ b/feature/edit/src/main/java/com/dev/innerview/feature/edit/EditHomeScreen.kt
@@ -1,8 +1,10 @@
 package com.dev.innerview.feature.edit
 
 import android.content.res.Configuration
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,6 +24,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.drawscope.Stroke
@@ -32,6 +37,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.dev.innerview.core.designsystem.component.InnerViewDialog
 import com.dev.innerview.core.designsystem.component.InnerViewDialogTextField
+import com.dev.innerview.core.designsystem.component.InnerViewDropdownMenu
+import com.dev.innerview.core.designsystem.component.InnerViewDropdownMenuItem
 import com.dev.innerview.core.designsystem.component.InnerViewFloatingActionButton
 import com.dev.innerview.core.designsystem.component.InnerViewTopAppBar
 import com.dev.innerview.core.designsystem.component.InterviewGroupCard
@@ -66,6 +73,7 @@ internal fun EditHomeScreen(
         maxInnerProjectTitleLength = viewModel.maxInnerProjectTitleLength,
         updateDialogInnerProjectTitle = viewModel::updateDialogInnerProjectTitle,
         addInnerProject = viewModel::addInnerProject,
+        deleteInnerProject = viewModel::deleteInnerProject,
         navigateToEdit = navigateToEdit,
     )
 }
@@ -78,6 +86,7 @@ private fun EditHomeContent(
     maxInnerProjectTitleLength: Int,
     updateDialogInnerProjectTitle: (String) -> Unit,
     addInnerProject: () -> Unit,
+    deleteInnerProject: (Int) -> Unit,
     navigateToEdit: (Int) -> Unit,
 ) {
     Box(
@@ -101,6 +110,7 @@ private fun EditHomeContent(
             ) {
                 InnerProjectList(
                     interviewGroups = editHomeUiState.innerProjects,
+                    deleteInnerProject = deleteInnerProject,
                     navigateToEdit = navigateToEdit
                 )
                 InnerViewFloatingActionButton(
@@ -138,6 +148,7 @@ private fun EditHomeContent(
 @Composable
 private fun InnerProjectList(
     interviewGroups: ImmutableList<InnerProject>,
+    deleteInnerProject: (Int) -> Unit,
     navigateToEdit: (Int) -> Unit,
 ) {
     val lazyGridState = rememberLazyGridState()
@@ -155,33 +166,92 @@ private fun InnerProjectList(
             horizontalArrangement = Arrangement.spacedBy(Paddings.medium),
         ) {
             items(interviewGroups, key = { it.id }) {
-                InterviewGroupCard(
-                    modifier = Modifier
-                        .height(240.dp)
-                        .clickable { navigateToEdit(it.id) },
-                    filePath = it.innerProjectComponents.media.firstOrNull()?.filePath ?: ""
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .align(Alignment.BottomStart)
-                            .padding(start = Paddings.medium, bottom = Paddings.medium)
-                    ) {
-                        OutlinedText(
-                            text = it.title ?: "empty",
-                            style = MaterialTheme.typography.titleSmall.copy(
-                                color = MaterialTheme.colorScheme.onTertiary
-                            ),
-                            outlineColor = MaterialTheme.colorScheme.tertiary,
-                            outlineDrawStyle = Stroke(
-                                width = 5f
-                            )
-                        )
-                    }
-                }
+                InnerProjectCard(
+                    innerProject = it,
+                    deleteInnerProject = deleteInnerProject,
+                    navigateToEdit = navigateToEdit
+                )
             }
             item(span = { GridItemSpan(maxLineSpan) }) {
                 Spacer(modifier = Modifier.height(80.dp))
             }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun InnerProjectCard(
+    modifier: Modifier = Modifier,
+    innerProject: InnerProject,
+    deleteInnerProject: (Int) -> Unit,
+    navigateToEdit: (Int) -> Unit,
+) {
+
+    var dropDownExpanded by remember { mutableStateOf(false) }
+    var deleteDialogVisible by remember { mutableStateOf(false) }
+
+    InterviewGroupCard(
+        modifier = modifier
+            .height(240.dp)
+            .combinedClickable(
+                onClick = { navigateToEdit(innerProject.id) },
+                onLongClick = { dropDownExpanded = true }
+            ),
+        filePath = innerProject.innerProjectComponents.media.firstOrNull()?.filePath ?: ""
+    ) {
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(start = Paddings.medium, bottom = Paddings.medium)
+        ) {
+            OutlinedText(
+                text = innerProject.title,
+                style = MaterialTheme.typography.titleSmall.copy(
+                    color = MaterialTheme.colorScheme.onTertiary
+                ),
+                outlineColor = MaterialTheme.colorScheme.tertiary,
+                outlineDrawStyle = Stroke(
+                    width = 5f
+                )
+            )
+            InnerViewDropdownMenu(
+                modifier = Modifier,
+                expanded = dropDownExpanded,
+                onDismissRequest = { dropDownExpanded = false }
+            ) {
+                InnerViewDropdownMenuItem(
+                    text = stringResource(R.string.feature_edit_inner_project_delete_confirm_text),
+                    style = MaterialTheme.typography.labelLarge.copy(
+                        color = MaterialTheme.colorScheme.error
+                    ),
+                    onClick = {
+                        deleteDialogVisible = true
+                        dropDownExpanded = false
+                    },
+                    onDismissRequest = { dropDownExpanded = false }
+                )
+            }
+        }
+
+        if (deleteDialogVisible) {
+            InnerViewDialog(
+                titleText = stringResource(
+                    R.string.feature_edit_inner_project_delete_dialog_title,
+                    innerProject.title
+                ),
+                contentText = stringResource(
+                    R.string.feature_edit_inner_project_delete_dialog_content,
+                    innerProject.title
+                ),
+                confirmText = stringResource(R.string.feature_edit_inner_project_delete_confirm_text),
+                dismissText = stringResource(R.string.feature_edit_inner_project_delete_dismiss_text),
+                onDismissRequest = { deleteDialogVisible = false },
+                onConfirmRequest = {
+                    deleteInnerProject(innerProject.id)
+                    deleteDialogVisible = false
+                }
+            )
         }
     }
 }
@@ -211,6 +281,7 @@ private fun EditHomeContentPreview() {
             maxInnerProjectTitleLength = 0,
             updateDialogInnerProjectTitle = {},
             addInnerProject = {},
+            deleteInnerProject = {},
             navigateToEdit = {}
         )
     }

--- a/feature/edit/src/main/java/com/dev/innerview/feature/edit/EditHomeViewModel.kt
+++ b/feature/edit/src/main/java/com/dev/innerview/feature/edit/EditHomeViewModel.kt
@@ -3,6 +3,7 @@ package com.dev.innerview.feature.edit
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.dev.innerview.core.domain.usecase.AddInnerProjectUseCase
+import com.dev.innerview.core.domain.usecase.DeleteInnerProjectUseCase
 import com.dev.innerview.core.domain.usecase.GetInnerProjectUseCase
 import com.dev.innerview.feature.edit.model.EditHomeUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -20,7 +21,8 @@ import javax.inject.Inject
 @HiltViewModel
 class EditHomeViewModel @Inject constructor(
     getInnerProjectUseCase: GetInnerProjectUseCase,
-    private val addInnerProjectUseCase: AddInnerProjectUseCase
+    private val addInnerProjectUseCase: AddInnerProjectUseCase,
+    private val deleteInnerProjectUseCase: DeleteInnerProjectUseCase
 ) : ViewModel() {
 
     val maxInnerProjectTitleLength = 40
@@ -65,6 +67,12 @@ class EditHomeViewModel @Inject constructor(
             _editHomeUiState.update {
                 it.copy(dialogInnerProjectTitle = title)
             }
+        }
+    }
+
+    fun deleteInnerProject(innerProjectId: Int) {
+        viewModelScope.launch {
+            deleteInnerProjectUseCase(innerProjectId)
         }
     }
 }

--- a/feature/edit/src/main/res/values/strings.xml
+++ b/feature/edit/src/main/res/values/strings.xml
@@ -35,5 +35,8 @@
     <string name="feature_edit_media_item_content_left_cut">현재부터 자르기</string>
     <string name="feature_edit_media_item_content_delete">삭제</string>
 
-
+    <string name="feature_edit_inner_project_delete_confirm_text">삭제</string>
+    <string name="feature_edit_inner_project_delete_dismiss_text">취소</string>
+    <string name="feature_edit_inner_project_delete_dialog_title">%1$s 삭제</string>
+    <string name="feature_edit_inner_project_delete_dialog_content">%1$s 프로젝트를 삭제하시겠습니까?\n편집 내용이 모두 삭제되며, 원본 영상은 유지됩니다.\n삭제 전 다시 한번 확인해 주시기 바랍니다.\n삭제를 계속하시겠습니까?</string>
 </resources>


### PR DESCRIPTION
## 개요
- 프로젝트 삭제 기능 추가
- deleteInnerProject Overloading 추가
  - innerProjectId를 받는 함수는 편집한 프로젝트 삭제용으로 원본파일 삭제하지 않음
  - innerViewId와 interviewGroupId, question을 받는 함수는 촬영 중 삭제 기능으로 원본파일 삭제함
- InnerView, InterviewGroup, Question, InnerProject 삭제 기능에서 원본파일 삭제 로직 추가

## 스크린샷
![GIF](https://github.com/user-attachments/assets/60eec6e9-255e-4127-aafc-e66ce32cac65)
